### PR TITLE
[FR] Better handle the 'date' template (closes #196)

### DIFF
--- a/scripts/lang/fr/__init__.py
+++ b/scripts/lang/fr/__init__.py
@@ -438,7 +438,8 @@ templates_multi = {
     "couleur": "color(parts[1])",
     # {{date}}
     # {{date|1850}}
-    "date": "term(parts[1] if len(parts) > 1 else 'Date à préciser')",
+    # {{date|lang=fr|vers 980}}
+    "date": "term(capitalize(parts[1]) if len(parts) > 1 else 'Date à préciser')",
     # {{divinités|fr|grecques}}
     "divinités": "term('Divinité')",
     # {{fchim|H|2|O}}

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -371,6 +371,8 @@ def test_parse_word(word, pronunciation, genre, etymology, definitions, variant,
         ("{{date|lang=fr}}", "<i>(Date à préciser)</i>"),
         ("{{date|1957}}", "<i>(1957)</i>"),
         ("{{date|1957-2057}}", "<i>(1957-2057)</i>"),
+        ("{{date|lang=fr|vers 980}}", "<i>(Vers 980)</i>"),
+        ("{{date|lang=fr|vers l'an V}}", "<i>(Vers l'an V)</i>"),
         ("du XX{{e}} siècle", "du XX<sup>e</sup> siècle"),
         (
             "{{étyl|grc|fr|mot=ἄκρος|tr=akros|sens=extrémité}}",


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/lune

- [x] Fixes #196
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
