### PR TITLE
[FR] Handle empty date template (closes #240)

### DIFF
--- a/scripts/lang/fr/__init__.py
+++ b/scripts/lang/fr/__init__.py
@@ -436,10 +436,6 @@ templates_multi = {
     "créatures": "term('Mythologie')",
     # {{couleur|#B0F2B6}}
     "couleur": "color(parts[1])",
-    # {{date}}
-    # {{date|1850}}
-    # {{date|lang=fr|vers 980}}
-    "date": "term(capitalize(parts[1]) if len(parts) > 1 else 'Date à préciser')",
     # {{fchim|H|2|O}}
     "fchim": "chimy(parts[1:])",
     # XIX{{e}}
@@ -687,6 +683,19 @@ def last_template_handler(template: Tuple[str, ...], locale: str) -> str:
         >>> last_template_handler(["composé de", "느낌", "tr1=neukkim", "sens1=sensation", "표", "tr2=-pyo", "sens2=symbole", "lang=ko", "m=1"], "fr")
         'Dérivé de 느낌, <i>neukkim</i> («&nbsp;sensation&nbsp;») avec le suffixe 표, <i>-pyo</i> («&nbsp;symbole&nbsp;»)'
 
+        >>> last_template_handler(["date", "lang=fr", ""], "fr")
+        '<i>(Date à préciser)</i>'
+        >>> last_template_handler(["date", "", "lang=fr"], "fr")
+        '<i>(Date à préciser)</i>'
+        >>> last_template_handler(["date", "lang=fr"], "fr")
+        '<i>(Date à préciser)</i>'
+        >>> last_template_handler(["date", "1957"], "fr")
+        '<i>(1957)</i>'
+        >>> last_template_handler(["date", "1957"], "fr")
+        '<i>(1957)</i>'
+        >>> last_template_handler(["date", "lang=fr", "vers l'an V"], "fr")
+        "<i>(Vers l'an V)</i>"
+
         >>> last_template_handler(["siècle"], "fr")
         '<i>(Siècle à préciser)</i>'
         >>> last_template_handler(["siècle", "lang=fr", "?"], "fr")
@@ -713,10 +722,21 @@ def last_template_handler(template: Tuple[str, ...], locale: str) -> str:
     """
     from .langs import langs
     from ..defaults import last_template_handler as default
-    from ...user_functions import century, extract_keywords_from, italic, term
+    from ...user_functions import (
+        capitalize,
+        century,
+        extract_keywords_from,
+        italic,
+        term,
+    )
 
     tpl = template[0]
     parts = list(template[1:])
+
+    if tpl == "date":
+        extract_keywords_from(parts)
+        date = parts[-1] if parts and parts[-1] else "Date à préciser"
+        return term(capitalize(date))
 
     # Handle {{déverbal}} and {{dénominal}} template
     if tpl in ("dénominal", "déverbal"):

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -370,11 +370,6 @@ def test_parse_word(
         ("{{cf|lang=fr|in-|extinguible}}", "→ voir <i>in-</i> et <i>extinguible</i>"),
         ("{{circa|1150}}", "<i>(c. 1150)</i>"),
         ("{{couleur|#B0F2B6}}", "[RGB #B0F2B6]"),
-        ("{{date|lang=fr}}", "<i>(Date à préciser)</i>"),
-        ("{{date|1957}}", "<i>(1957)</i>"),
-        ("{{date|1957-2057}}", "<i>(1957-2057)</i>"),
-        ("{{date|lang=fr|vers 980}}", "<i>(Vers 980)</i>"),
-        ("{{date|lang=fr|vers l'an V}}", "<i>(Vers l'an V)</i>"),
         ("du XX{{e}} siècle", "du XX<sup>e</sup> siècle"),
         (
             "{{étyl|grc|fr|mot=ἄκρος|tr=akros|sens=extrémité}}",


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/boursi%C3%A8re
Ex: https://fr.wiktionary.org/wiki/r%C3%A9glage

- [x] Fixes #240
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
