### PR TITLE
[EN] Enhance support for 'm' and 'l' templates (closes #347)

### DIFF
--- a/scripts/transliterator.py
+++ b/scripts/transliterator.py
@@ -766,18 +766,23 @@ def transliterate(locale: str, text: str) -> str:
     """
     Return the transliterated form of *text*.
 
-    >>> transliterate("ar", "ا")
-    'ā'
-    >>> transliterate("ar", "بطيخ")
-    'bṭīḫ'
-    >>> transliterate("el", "α")
-    'a'
-    >>> transliterate("hi", "अ")
-    'a'
-    >>> transliterate("ru", "а")
-    'a'
-    >>> transliterate("ru", "дед")
-    'ded'
+        >>> transliterate("ar", "ا")
+        'ā'
+        >>> transliterate("ar", "بطيخ")
+        'bṭīḫ'
+        >>> transliterate("el", "α")
+        'a'
+        >>> transliterate("hi", "अ")
+        'a'
+        >>> transliterate("ru", "а")
+        'a'
+        >>> transliterate("ru", "дед")
+        'ded'
+        >>> transliterate("fr", "bim")
+        ''
     """
-    table = transliterations[locale]
-    return "".join(table[char] for char in text)
+    try:
+        table = transliterations[locale]
+    except KeyError:
+        return ""
+    return "".join(table.get(char, "") for char in text)

--- a/tests/data/en/us.wiki
+++ b/tests/data/en/us.wiki
@@ -3,7 +3,7 @@
 {{wikipedia}}
 
 ===Etymology 1===
-From {{etyl|enm|en}} {{m|enm|us}}, from {{etyl|ang|en}} {{m|ang|ūs||pos=dative personal pronoun|us}}, from {{etyl|gem-pro|en}} {{m|gem-pro|*uns||us}}, from {{etyl|ine-pro|en}} {{m|ine-pro|*ne-}}, {{m|ine-pro|*nō-}}, {{m|ine-pro|*n-ge-}}, {{m|ine-pro|*n-sme-||us}}. Cognate with {{cog|fy|us}}, {{m|fy|us|ús|us}}, {{cog|nds|us||us}}, {{cog|nl|ons||us}}, {{cog|de|uns||us}}, {{cog|da|os||us}}, {{cog|la|nōs||we, us}}.
+From {{inh|en|enm|us}}, from {{inh|en|ang|ūs||pos=dative personal pronoun|us}}, from {{inh|en|gem-pro|*uns||us}}, from {{der|en|ine-pro|*ne-}}, {{m|ine-pro|*nō-}}, {{m|ine-pro|*n-ge-}}, {{m|ine-pro|*n-sme-||us}}. Cognate with {{cog|fy|us}}, {{m|fy|us|ús|us}}, {{cog|nds|us||us}}, {{cog|nl|ons||us}}, {{cog|de|uns||us}}, {{cog|da|os||us}}, {{cog|la|nōs||we, us}}.
 
 ====Pronunciation====
 * {{qualifier|stressed}} {{enPR|ŭs}}, {{IPA|en|/ʌs/}}, {{IPA|en|/ʌz/}}
@@ -17,7 +17,7 @@ From {{etyl|enm|en}} {{m|enm|us}}, from {{etyl|ang|en}} {{m|ang|ūs||pos=dative 
 # {{lb|en|personal}} [[me|Me]] and at least one other person; the objective case of '''[[we]]'''.
 #* '''1611''', [[w:King James Version of the Bible|King James Version of the Bible]], ''[[s:Bible (King James)/Luke|Luke]] 1:1'':
 #*: Forasmuch as many have taken in hand to set forth in order a declaration of those things which are most surely believed among '''us'''...
-# {{lb|en|colloquial}} [[me|Me]].
+# {{lb|en|UK|colloquial}} [[me|Me]].
 #: ''Give '''us''' a look at your paper.''
 #: ''Give '''us''' your wallet!''
 # {{lb|en|Northern England}} [[our|Our]].
@@ -59,13 +59,13 @@ From {{etyl|enm|en}} {{m|enm|us}}, from {{etyl|ang|en}} {{m|ang|ūs||pos=dative 
 * Irish: {{t|ga|sinn|p}}
 *: Old Irish: {{t|sga|n-}}, {{t|sga|don-}}, {{t|sga|-unn}}
 * Italian: {{t+|it|noi}}, a noi, {{t+|it|ci}}
-* Japanese: wata (私達) ''[[or]]'' tachi (私達)
+* Japanese: 私達 (watashitachi)
 * Kabuverdianu: {{t|kea|nu}}
 * Kazakh: {{t+|kk|бізді}}
 {{trans-mid}}
 * Korean: {{t+|ko|우리}}
 * Kurdish:
-*: Sorani: {{t+|ku|ئێمە}}
+*: Central Kurdish: {{t|ckb|ئێمە}}
 * Latin: {{qualifier|accusative}} {{t+|la|nos}}, {{qualifier|dative}} {{t+|la|nobis}}, {{qualifier|ablative}} {{t+|la|nobis}}
 * Macedonian: {{t|mk|ни}}, {{t|mk|нас}}, {{t|mk|нам}}
 * Malay:
@@ -111,6 +111,8 @@ From {{etyl|enm|en}} {{m|enm|us}}, from {{etyl|ang|en}} {{m|ang|ūs||pos=dative 
 * {{l|en|our}}
 * {{l|en|ours}}
 
+{{English personal pronouns}}
+
 ====Determiner====
 {{en-det}}
 
@@ -122,6 +124,7 @@ From {{etyl|enm|en}} {{m|enm|us}}, from {{etyl|ang|en}} {{m|ang|ūs||pos=dative 
 
 ===Etymology 2===
 Derived from the similarity between the letter [[u]] and the Greek letter [[µ]].
+
 ====Symbol====
 {{head|en|symbol}}
 
@@ -130,7 +133,7 @@ Derived from the similarity between the letter [[u]] and the Greek letter [[µ]]
 #*:<nowiki>;</nowiki>wait 500 '''us'''
 #*'''2012''', Peter Feiler and David Gluch, ''Model-Based Engineering with AADL'':
 #*:The standard units are ns (nanoseconds), '''us''' (microseconds), ms (milliseconds), sec (seconds), min (minutes), and hr (hours).
-#*'''2014''', Michael Corey, ‎Jeff Szastak, ‎and Michael Webster, ''Virtualizing SQL Server with VMware: Doing IT Right'', p. 198:
+#*'''2014''', Michael Corey, Jeff Szastak, and Michael Webster, ''Virtualizing SQL Server with VMware: Doing IT Right'', p. 198:
 #*:Because the flash devices are local to the server, the latencies can be microseconds ('''us''') instead of milliseconds (ms) and eliminate some traffic that would normally have gone over the storage network.
 
 ===Etymology 3===
@@ -150,6 +153,7 @@ Derived from the similarity between the letter [[u]] and the Greek letter [[µ]]
 
 [[Category:English basic words]]
 [[Category:English first person pronouns]]
+[[Category:English heteronyms]]
 [[Category:English personal pronouns]]
 [[Category:English plural pronouns]]
 [[Category:English two-letter words]]
@@ -303,7 +307,10 @@ From {{inh|fro|la|ūsus}}.
 ==Old Frisian==
 
 ===Etymology===
-From {{inh|ofs|gem-pro|*uns}}, {{m|gem-pro|*unsiz}}.
+From {{inh|ofs|gem-pro|*uns}}, {{m|gem-pro|*unsiz}}. Cognates include {{cog|ang|ūs}}, {{cog|osx|ūs}} and {{cog|odt|uns}}.
+
+===Pronunciation===
+* {{IPA|ofs|/ˈuːs/}}
 
 ===Pronoun===
 {{head|ofs|pronoun|head=ūs}}
@@ -314,9 +321,31 @@ From {{inh|ofs|gem-pro|*uns}}, {{m|gem-pro|*unsiz}}.
 {{ofs-decl-ppron}}
 
 ====Descendants====
-* {{desc|frr|üüs}}
+* {{desc|frr|-}}
+*: Most dialects: {{l|frr|üs}}
+*: Sylt: {{l|frr|üüs}}
 * {{desc|stq|uus}}
 * {{desc|fy|ús}}
+
+====References====
+* {{R:ofs:Bremmer:2009}}
+
+----
+
+==Serbo-Croatian==
+
+===Etymology===
+From {{inh|sh|sla-pro|*ǫsъ}}.
+
+===Noun===
+{{sh-noun|g=f|head=ȕs}}
+
+# [[fishbone]]
+
+===References===
+* {{R:sh:HJP|f19gWBR9}}
+
+{{c|sh|Animal body parts|Bones}}
 
 ----
 

--- a/tests/data/fr/corps portant.wiki
+++ b/tests/data/fr/corps portant.wiki
@@ -6,7 +6,7 @@
 {{fr-rég|kɔʁ pɔʁ.tɑ̃}}
 '''corps portant''' {{pron|kɔʁ pɔʁ.tɑ̃|fr}} {{m}}
 [[Image:X24.jpg|thumb|upright=1.2|Martin Marietta X-24A construit pour un projet militaire américain expérimental de 1963 à 1975.]]
-# {{astronautique|fr}} {{term|}} [[aéronef|Aéronef]] à fuselage porteur, sur lequel la [[portance]] est produite par le [[fuselage]], destiné aux usages [[spatiaux]] ou [[hypersonique]]s, afin de limiter l'[[effet de traînée]] ou la [[surface de friction]].
+# {{astronautique|fr}} [[aéronef|Aéronef]] à fuselage porteur, sur lequel la [[portance]] est produite par le [[fuselage]], destiné aux usages [[spatiaux]] ou [[hypersonique]]s, afin de limiter l'[[effet de traînée]] ou la [[surface de friction]].
 # {{astronautique|fr}} {{term|aérodynamique}} Engin aérospatial possédant, à vitesse hypersonique, une portance qui lui assure une bonne manœuvrabilité lors de la rentrée atmosphérique.
 
 ==== {{S|vocabulaire}} ====

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -40,7 +40,7 @@ from scripts.utils import clean
         (
             "efficient",
             ["ɪˈfɪʃənt"],
-            "1398, “making,” from Old French, from Latin <i>efficientem</i>, nominative <b>efficiēns</b>, participle of <i>efficere</i> (“work out, accomplish”) (see <b>effect</b>). Meaning “productive, skilled” is from 1787. <i>Efficiency apartment</i> is first recorded 1930, American English.",  # noqa
+            "1398, “making,” from Old French, from Latin <i>efficientem</i>, nominative <i>efficiēns</i>, participle of <i>efficere</i> (“work out, accomplish”) (see <b>effect</b>). Meaning “productive, skilled” is from 1787. <i>Efficiency apartment</i> is first recorded 1930, American English.",  # noqa
             [
                 "making good, thorough, or careful use of resources; not consuming extra. Especially, making good use of time or energy",  # noqa
                 "expressing the proportion of consumed energy that was successfully used in a process; the ratio of useful output to total input",  # noqa
@@ -63,7 +63,7 @@ from scripts.utils import clean
         (
             "Mars",
             ["ˈmɑːz"],
-            "From Middle English <i>Mars</i>, from Latin <i>Mars</i> (“god of war”), from older Latin (older than 75 BC) <b>Māvors</b>. <b>𐌌𐌀𐌌𐌄𐌓𐌔</b> was his Oscan name. He was also known as <i>Marmor</i>, <i>Marmar</i> and <i>Maris</i>, the latter from the Etruscan deity Maris.",  # noqa
+            "From Middle English <i>Mars</i>, from Latin <i>Mars</i> (“god of war”), from older Latin (older than 75 BC) <i>Māvors</i>. <i>𐌌𐌀𐌌𐌄𐌓𐌔</i> was his Oscan name. He was also known as <i>Marmor</i>, <i>Marmar</i> and <i>Maris</i>, the latter from the Etruscan deity Maris.",  # noqa
             [
                 "<i>(astronomy)</i> The fourth planet in the solar system. Symbol: <b>♂</b>",
                 "<i>(Roman god)</i> The Roman god of war.",
@@ -75,7 +75,7 @@ from scripts.utils import clean
         (
             "on",
             ["ɒn"],
-            "From Middle English <i>on</i>, from Old English <i>on</i>, <b>an</b> (“on, upon, onto, in, into”), from Proto-Germanic <i>*ana</i> (“on, at”), from Proto-Indo-European <i>*h₂en-</i>. Cognate with North Frisian <i>a</i> (“on, in”), Saterland Frisian <i>an</i> (“on, at”), West Frisian <i>oan</i> (“on, at”), Dutch <i>aan</i> (“on, at, to”), Low German <i>an</i> (“on, at”), German <i>an</i> (“to, at, on”), Swedish <i>å</i> (“on, at, in”), Faroese <i>á</i> (“on, onto, in, at”), Icelandic <i>á</i> (“on, in”), Gothic <i>𐌰𐌽𐌰</i>, Ancient Greek <i>ἀνά</i> (“up, upon”), Albanian <i>në</i> (“in”); and from Old Norse <i>upp á</i>: Danish <i>på</i>, Swedish <i>på</i>, Norwegian <i>på</i>, see <b>upon</b>.",  # noqa
+            "From Middle English <i>on</i>, from Old English <i>on</i>, <i>an</i> (“on, upon, onto, in, into”), from Proto-Germanic <i>*ana</i> (“on, at”), from Proto-Indo-European <i>*h₂en-</i>. Cognate with North Frisian <i>a</i> (“on, in”), Saterland Frisian <i>an</i> (“on, at”), West Frisian <i>oan</i> (“on, at”), Dutch <i>aan</i> (“on, at, to”), Low German <i>an</i> (“on, at”), German <i>an</i> (“to, at, on”), Swedish <i>å</i> (“on, at, in”), Faroese <i>á</i> (“on, onto, in, at”), Icelandic <i>á</i> (“on, in”), Gothic <i>𐌰𐌽𐌰</i>, Ancient Greek <i>ἀνά</i> (“up, upon”), Albanian <i>në</i> (“in”); and from Old Norse <i>upp á</i>: Danish <i>på</i>, Swedish <i>på</i>, Norwegian <i>på</i>, see <b>upon</b>.",  # noqa
             [
                 "In the state of being active, functioning or operating.",
                 "Performing according to schedule; taking place.",
@@ -127,7 +127,7 @@ from scripts.utils import clean
         (
             "portmanteau",
             ["pɔːtˈmæn.təʊ"],
-            "French <i>portemanteau</i> (“coat stand”), from <b>porte</b> (“carry”) + <b>manteau</b> (“coat”).",
+            "French <i>portemanteau</i> (“coat stand”), from <i>porte</i> (“carry”) + <i>manteau</i> (“coat”).",
             [
                 "A large travelling case usually made of leather, and opening into two equal sections.",
                 "<i>(Australia, dated)</i> A schoolbag.",
@@ -150,7 +150,7 @@ from scripts.utils import clean
         (
             "the",
             ["ˈðiː"],
-            "From Middle English <i>the</i>, from Old English <i>þē</i> (“the, that”), a late variant of <b>sē</b>. Originally masculine nominative, in Middle English it superseded all previous Old English forms (<b>sē</b>, <b>sēo</b>, <b>þæt</b>, <b>þā</b>), from Proto-Germanic <i>*sa</i>, from Proto-Indo-European <i>*só</i>. Cognate with Saterland Frisian <i>die</i> (“the”), West Frisian <i>de</i> (“the”), Dutch <i>de</i> (“the”), German Low German <i>de</i> (“the”), German <i>der</i> (“the”), Danish <i>de</i> (“the”), Swedish <i>de</i> (“the”), Icelandic <i>sá</i> (“the”).",  # noqa
+            "From Middle English <i>the</i>, from Old English <i>þē</i> (“the, that”), a late variant of <i>sē</i>. Originally masculine nominative, in Middle English it superseded all previous Old English forms (<i>sē</i>, <i>sēo</i>, <i>þæt</i>, <i>þā</i>), from Proto-Germanic <i>*sa</i>, from Proto-Indo-European <i>*só</i>. Cognate with Saterland Frisian <i>die</i> (“the”), West Frisian <i>de</i> (“the”), Dutch <i>de</i> (“the”), German Low German <i>de</i> (“the”), German <i>der</i> (“the”), Danish <i>de</i> (“the”), Swedish <i>de</i> (“the”), Icelandic <i>sá</i> (“the”).",  # noqa
             [
                 "<i>Definite grammatical article that implies necessarily that an entity it articulates is presupposed; something already mentioned, or completely specified later in that same sentence, or assumed already completely specified.</i> <small>[from 10th c.]</small>",  # noqa
                 "<i>Used before a noun modified by a restrictive relative clause, indicating that the noun refers to a single referent defined by the relative clause.</i>",  # noqa
@@ -183,10 +183,10 @@ from scripts.utils import clean
         (
             "us",
             ["ʌs", "ʌz"],
-            "From Middle English <b>us</b>, from Old English <b>ūs</b> (“us”), from Proto-Germanic <b>*uns</b> (“us”), from Proto-Indo-European <b>*ne-</b>, <b>*nō-</b>, <b>*n-ge-</b>, <b>*n-sme-</b> (“us”). Cognate with West Frisian <i>us</i>, <b>ús</b> (“us”), Low German <i>us</i> (“us”), Dutch <i>ons</i> (“us”), German <i>uns</i> (“us”), Danish <i>os</i> (“us”), Latin <i>nōs</i> (“we, us”).",  # noqa
+            "From Middle English <i>us</i>, from Old English <i>ūs</i> (“us”), from Proto-Germanic <i>*uns</i> (“us”), from Proto-Indo-European <i>*ne-</i>, <i>*nō-</i>, <i>*n-ge-</i>, <i>*n-sme-</i> (“us”). Cognate with West Frisian <i>us</i>, <i>ús</i> (“us”), Low German <i>us</i> (“us”), Dutch <i>ons</i> (“us”), German <i>uns</i> (“us”), Danish <i>os</i> (“us”), Latin <i>nōs</i> (“we, us”).",  # noqa
             [
                 "<i>(personal)</i> Me and at least one other person; the objective case of <b>we</b>.",
-                "<i>(colloquial)</i> Me.",
+                "<i>(UK, colloquial)</i> Me.",
                 "<i>(Northern England)</i> Our.",
                 "The speakers/writers, or the speaker/writer and at least one other person.",
                 "<i>Alternative spelling of</i> <b>µs</b>: microsecond",
@@ -321,10 +321,6 @@ def test_parse_word(word, pronunciations, etymology, definitions, page):
         ),
         ("{{IPAchar|[tʃ]|lang=en}}", "[tʃ]"),
         ("{{IPAfont|[[ʌ]]}}", "⟨ʌ⟩"),
-        ("{{l|en|water vapour}}", "water vapour"),
-        ("{{ll|en|cod}}", "cod"),
-        ("{{link|en|water vapour}}", "water vapour"),
-        ("{{m|en|more}}", "<b>more</b>"),
         (
             "{{n-g|Definite grammatical}}",
             "<i>Definite grammatical</i>",


### PR DESCRIPTION
Ex: https://en.wiktionary.org/wiki/Iraq

- [x] Fixes #347
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
