### PR TITLE
fix #354: [FR] Support for e/ème/er/ère templates

### DIFF
--- a/scripts/lang/fr/__init__.py
+++ b/scripts/lang/fr/__init__.py
@@ -448,6 +448,9 @@ templates_italic = {
 # Un documentation des fonctions disponibles se trouve dans le fichier HTML suivant :
 #   html/scripts/user_functions.html
 templates_multi = {
+    # {{1er}}
+    # {{1er|mai}}
+    "1er": "f\"1{superscript('er')}{'&nbsp;' + parts[1] if len(parts) > 1 else ''}\"",
     # {{comparatif de|bien|fr|adv}}
     "comparatif de": "sentence(parts)",
     # {{cf}}
@@ -472,10 +475,14 @@ templates_multi = {
     # XIX{{e}}
     # {{e|-1}}
     "e": "superscript(parts[1] if len(parts) > 1 else 'e')",
+    # XIX{{ème}}
+    "ème": "superscript(parts[1] if len(parts) > 1 else 'e')",
+    # {{er}}
+    "er": "superscript(parts[1] if len(parts) > 1 else 'er')",
+    # {{ère}}
+    "ère": "superscript(parts[1] if len(parts) > 1 else 'ère')",
     # XIV{{exp|e}}
     "exp": "superscript(parts[1] if len(parts) > 1 else 'e')",
-    # {{er}}
-    "er": "superscript('er')",
     # {{emploi|au passif}}
     "emploi": "term(capitalize(parts[1]))",
     # {{#expr: 2 ^ 30}}
@@ -511,6 +518,10 @@ templates_multi = {
     "nom w pc": "person(word, parts[1:])",
     # {{nombre romain|12}}
     "nombre romain": "int_to_roman(int(parts[1]))",
+    # {{numéro}}
+    "numéro": "f\"n{superscript('o')}\"",
+    # {{o}}
+    "o": "superscript('o')",
     # {{petites capitales|Dupont}}
     "petites capitales": "small_caps(parts[1])",
     # {{pc|Dupont}}

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -364,6 +364,8 @@ def test_parse_word(
 @pytest.mark.parametrize(
     "wikicode, expected",
     [
+        ("{{1er}}", "1<sup>er</sup>"),
+        ("{{1er|mai}}", "1<sup>er</sup>&nbsp;mai"),
         ("{{adj-indéf-avec-de}}", "<i>(Avec de)</i>"),
         ("{{ancre|sens_sexe}}", ""),
         ("{{emploi|au passif}}", "<i>(Au passif)</i>"),
@@ -383,6 +385,9 @@ def test_parse_word(
         ("{{diminutif|fr|de=balle}}", "diminutif"),
         ("{{diminutif|fr|m=1}}", "Diminutif"),
         ("du XX{{e}} siècle", "du XX<sup>e</sup> siècle"),
+        ("M{{e|me}}", "M<sup>me</sup>"),
+        ("du XX{{ème}} siècle", "du XX<sup>e</sup> siècle"),
+        ("le 1{{er}}", "le 1<sup>er</sup>"),
         (
             "{{étyl|grc|fr|mot=ἄκρος|tr=akros|sens=extrémité}}",
             "grec ancien ἄκρος, <i>akros</i> («&nbsp;extrémité&nbsp;»)",
@@ -418,6 +423,8 @@ def test_parse_word(
         ("{{région|Lorraine et Dauphiné}}", "<i>(Lorraine et Dauphiné)</i>"),
         ("{{régionalisme}}", "<i>(Régionalisme)</i>"),
         ("{{régionalisme|Bretagne|fr}}", "<i>(Bretagne)</i>"),
+        ("{{numéro}}", "n<sup>o</sup>"),
+        ("{{o}}", "<sup>o</sup>"),
         ("{{pron|zjø|fr}}", "\\zjø\\"),
         ("{{pron-API|/j/}}", "/j/"),
         ("{{recons|lang-mot-vedette=fr|sporo|lang=frk|sc=Latn}}", "*<i>sporo</i>"),


### PR DESCRIPTION
Also fix 'o', 'numéro', '1er' templates

- [x] Fixes #354
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.