### PR TITLE
fix #503: [FR] Ignore the 'lien-ancre-étym' template

### DIFF
--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -178,6 +178,7 @@ templates_ignored = (
     "fr-rég",
     "ibid",
     "Import",
+    "lien-ancre-étym",
     "lien web",
     "Modèle",
     "Ouvrage",


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/DH