### PR TITLE
fix #522: [CA] Handle the 'pron' template

### DIFF
--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -209,6 +209,8 @@ def test_parse_word(word, pronunciations, genre, etymology, definitions, page):
         ("{{marca|ca|valencià-verb}}", "<i>(valencià)</i>"),
         ("{{marca-nocat|ca|balear}}", "<i>(balear)</i>"),
         ("{{marca-nocat|ca|occidental|balear}}", "<i>(occidental, balear)</i>"),
+        ("{{pron|ca|/kənˈta/}}", "/kənˈta/"),
+        ("{{pron|en|/əˈkrɔs/|/əˈkrɑs/}}", "/əˈkrɔs/, /əˈkrɑs/"),
         ("{{q|tenir bona planta}}", "<i>(tenir bona planta)</i>"),
         ("{{q|{{m}}}}", "<i>(m.)</i>"),
         ("{{etim-s|ca|XIV}}", "segle XIV"),

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -92,6 +92,8 @@ templates_multi = {
     # {{marca-nocat|ca|balear}}
     # {{marca-nocat|ca|occidental|balear}}
     "marca-nocat": "term(lookup_italic(concat(parts, sep=', ', indexes=[2, 3, 4, 5]), 'ca'))",
+    # {{pron|hi|/baːzaːr/}}
+    "pron": "', '.join(parts[2:])",
     # {{q|tenir bona planta}}
     "q": "term(parts[-1])",
     # {{etim-s|ca|XIV}}


### PR DESCRIPTION
Ex: https://ca.wiktionary.org/wiki/%E0%A4%9C%E0%A4%BC