### PR TITLE
fix #516: [CA] Handle the 'doblet' template

### DIFF
--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -193,6 +193,7 @@ def test_parse_word(word, pronunciations, genre, etymology, definitions, page):
     "wikicode, expected",
     [
         ("{{color|#E01010}}", "[RGB #E01010]"),
+        ("{{doblet|ca|Castellar}}", "<i>Castellar</i>"),
         ("{{e|la|lupus}}", "lupus"),
         (
             "{{forma-|abreujada|ca|bicicleta}}",

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -76,6 +76,8 @@ templates_italic = {
 templates_multi = {
     # {{color|#E01010}}
     "color": "color(parts[1])",
+    # {{doblet|ca|Castellar}}
+    "doblet": "italic(parts[-1])",
     # {{e|la|lupus}}
     "e": "parts[2]",
     # {{forma-|abreujada|ca|bicicleta}}


### PR DESCRIPTION
Ex: https://ca.wiktionary.org/wiki/Catllar