### PR TITLE
fix #536: [FR] Better support of 'lien' template

### DIFF
--- a/wikidict/lang/fr/template_handlers.py
+++ b/wikidict/lang/fr/template_handlers.py
@@ -394,8 +394,10 @@ def render_lien(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     'フランス, <i>Furansu</i> («&nbsp;France&nbsp;»)'
     >>> render_lien("lien", ["camara", "la"], defaultdict(str, {"sens":"voute, plafond vouté"}))
     'camara («&nbsp;voute, plafond vouté&nbsp;»)'
+    >>> render_lien("lien", ["sto", "la"], defaultdict(str, {"dif": "stare"}))
+    'stare'
     """
-    phrase = parts.pop(0)
+    phrase = data["dif"] or parts.pop(0)
     if data["tr"]:
         phrase += f", {italic(data['tr'])}"
     if data["sens"]:


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/%C3%AAtre

- [x] Fixes #536
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
