### PR TITLE
fix #539: [FR] Better support of 'étyl' template

### DIFF
--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -193,7 +193,7 @@ from wikidict.utils import process_templates
             "employer",
             ["ɑ̃.plwa.je"],
             "",
-            "Du latin <i>implico</i> («&nbsp;impliquer&nbsp;»).",
+            "Du latin <i>implicāre</i> («&nbsp;impliquer&nbsp;»).",
             [
                 "Utiliser ; user ; se servir de.",
                 "<i>(Spécialement)</i> <i>(Grammaire)</i> S’en servir en parlant ou en écrivant, en parlant d'une phrase, d'un mot ou d'une locution.",  # noqa

--- a/wikidict/lang/fr/template_handlers.py
+++ b/wikidict/lang/fr/template_handlers.py
@@ -311,6 +311,8 @@ def render_etyl(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     'latin <i>dithyrambicus</i>'
     >>> render_etyl("étyl", ["no", "fr"], defaultdict(str, {"mot":"ski"}))
     'norvégien <i>ski</i>'
+    >>> render_etyl("étyl", ["la", "fr", "sequor"], defaultdict(str, {"dif": "sequi"}))
+    'latin <i>sequi</i>'
     >>> render_etyl("étyl", ["la", "fr"], defaultdict(str, {"mot":"invito", "type":"verb"}))
     'latin <i>invito</i>'
     >>> render_etyl("étyl", ["grc", "fr"], defaultdict(str, {"mot":"λόγος", "tr":"lógos", "type":"nom", "sens":"étude"}))
@@ -345,6 +347,8 @@ def render_etyl(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
             data["tr"] = part
         elif not data["sens"]:
             data["sens"] = part
+    if data["dif"]:
+        data["mot"] = data["dif"]
     if data["tr"]:
         if data["mot"]:
             phrase += f" {data['mot']},"


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/suivre