### PR TITLE
fix #560: [FR] Review handling of the 'siècle2' template

### DIFF
--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -544,8 +544,6 @@ templates_multi = {
     # {{région|Lorraine et Dauphiné}}
     "région": "term(capitalize(parts[1] if len(parts) > 1 else 'régionalisme'))",
     "régionalisme": "term(capitalize(parts[1] if len(parts) > 1 else 'régionalisme'))",
-    # {{siècle2|XIX}}
-    "siècle2": 'f"{parts[1]}ème"',
     # {{smcp|Dupont}}
     "smcp": "small_caps(parts[1])",
     # {{SIC}}

--- a/wikidict/lang/fr/template_handlers.py
+++ b/wikidict/lang/fr/template_handlers.py
@@ -7,8 +7,10 @@ from ...user_functions import (
     capitalize,
     century,
     extract_keywords_from,
+    int_to_roman,
     italic,
     strong,
+    superscript,
     term,
 )
 
@@ -510,6 +512,27 @@ def render_siecle(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     return term(phrase)
 
 
+def render_siecle2(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
+    """
+    >>> render_siecle2("siècle2", ["1"], defaultdict(str))
+    'I<sup>er</sup>'
+    >>> render_siecle2("siècle2", ["I"], defaultdict(str))
+    'I<sup>er</sup>'
+    >>> render_siecle2("siècle2", ["i"], defaultdict(str))
+    'I<sup>er</sup>'
+    >>> render_siecle2("siècle2", ["18"], defaultdict(str))
+    'XVIII<sup>e</sup>'
+    >>> render_siecle2("siècle2", ["XVIII"], defaultdict(str))
+    'XVIII<sup>e</sup>'
+    >>> render_siecle2("siècle2", ["xviii"], defaultdict(str))
+    'XVIII<sup>e</sup>'
+    """
+    number = parts[0]
+    number = int_to_roman(int(number)) if number.isnumeric() else number.upper()
+    suffix = "er" if number == "I" else "e"
+    return f"{number}{superscript(suffix)}"
+
+
 def render_suisse(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     """
     >>> render_suisse("Suisse", ["fr"], defaultdict(str, {"précision":"Fribourg, Valais, Vaud"}))
@@ -595,6 +618,7 @@ template_mapping = {
     "recons": render_recons,
     "reverlanisation": render_agglutination,
     "siècle": render_siecle,
+    "siècle2": render_siecle2,
     "Suisse": render_suisse,
     "supplétion": render_suppletion,
     "syncope": render_agglutination,


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/imp%C3%A9rial

- [x] Fixes #560
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
