### PR TITLE
fix #568: Fix handling of imbricated templates 'w' -> 'pc'

### DIFF
--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -75,9 +75,21 @@ def last_template_handler(
 
 def render_wikilink(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     """
+    >>> render_wikilink("w", [], defaultdict(str))
+    ''
     >>> render_wikilink("w", ["Li Ptit Prince (roman)", "Li Ptit Prince"], defaultdict(str, {"lang": "wa"}))
     'Li Ptit Prince'
     >>> render_wikilink("w", ["Gesse aphaca", "Lathyrus aphaca"], defaultdict(str))
     'Lathyrus aphaca'
-    """
-    return parts[-1]
+    >>> render_wikilink("w", [], defaultdict(str, {"Paulin <span style": "'font-variant:small-caps'>Paris</span>", "lang": "fr"}))
+    "Paulin <span style='font-variant:small-caps'>Paris</span>"
+    """  # noqa
+    if parts:
+        return parts[-1]
+
+    # Possible imbricated templates: {{w| {{pc|foo bar}} }}
+    if data:
+        return "".join(f"{k}={v}" for k, v in data.items() if k != "lang")
+
+    # Should not happen as it is already handled in utils.transform()
+    return ""

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -419,10 +419,8 @@ def transform(word: str, template: str, locale: str) -> str:
     """Convert the data from the *template" template.
     This function also checks for template style.
 
-        >>> transform("foo", "w|ISO 639-3", "fr")
-        'ISO 639-3'
-        >>> transform("foo spaces", "w | ISO 639-3", "fr")
-        'ISO 639-3'
+        >>> transform("séga", "w", "fr")
+        'séga'
         >>> transform("foo", "formatnum:123", "fr")
         '123'
         >>> transform("foo", "grammaire|fr", "fr")
@@ -472,7 +470,7 @@ def transform(word: str, template: str, locale: str) -> str:
     # Magic words
     if tpl in MAGIC_WORDS:
         return MAGIC_WORDS[tpl]
-    elif tpl == "PAGENAME":
+    elif tpl == "PAGENAME" or (tpl == "w" and len(parts) == 1):
         return word.replace("_", " ")
 
     # Convert *parts* from a list to a tuple because list are not hashable and thus cannot be used


### PR DESCRIPTION
Ex:
- https://fr.wiktionary.org/wiki/Apremont
- https://fr.wiktionary.org/wiki/Aridam%C3%A9rique
- https://fr.wiktionary.org/wiki/s%C3%A9ga

- [x] Fixes #568
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
