### PR TITLE
fix #343: [FR] Add support for the 'Deva' template

### DIFF
--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -393,6 +393,7 @@ def test_parse_word(
             "{{étyl|grc|fr|mot=ἄκρος|tr=akros|sens=extrémité}}",
             "grec ancien ἄκρος, <i>akros</i> («&nbsp;extrémité&nbsp;»)",
         ),
+        ("{{Deva|[[देव]]|deva|divin}}", "देव"),
         ("{{divinités|fr|grecques}}", "<i>(Divinité)</i>"),
         ("{{info lex|boulangerie}}", "<i>(Boulangerie)</i>"),
         ("{{info lex|équitation|sport}}", "<i>(Équitation, Sport)</i>"),

--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -465,6 +465,8 @@ templates_multi = {
     "créatures": "term('Mythologie')",
     # {{couleur|#B0F2B6}}
     "couleur": "color(parts[1])",
+    # {{Deva|[[देव]]|deva|divin}}
+    "Deva": "parts[1].strip('[]')",
     # {{déverbal de|haler|fr}}
     "déverbal de": 'f"Déverbal de {italic(parts[1])}"',
     # {{dénominal de|affection|fr}}


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/d%C3%A9vanagari

- [x] Fixes #343
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
