### PR TITLE
fix #594: [PT] Words outside the 'escopos' list should not be lowercased

### DIFF
--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -118,7 +118,7 @@ from wikidict.utils import process_templates
             "",
             [
                 '<i>(antigo)</i> contração do pronome pessoal "te" com o pronome pessoal ou demonstrativo "o"',
-                "<i>(coloquial e brasil)</i> forma aferética (muito comum na linguagem falada) de estou",
+                "<i>(coloquial e Brasil)</i> forma aferética (muito comum na linguagem falada) de estou",
             ],
         ),
         (
@@ -146,10 +146,6 @@ def test_parse_word(word, pronunciations, genre, etymology, definitions, page):
     [
         ("{{AFI|/k/|pt}}", "/k/"),
         ("{{barra de cor|yellow|#FFFF00}}", "[RGB #FFFF00]"),
-        ("{{escopo|Pecuária}}", "<i>(Pecuária)</i>"),
-        ("{{escopo|pt|estrangeirismo}}", "<i>(estrangeirismo)</i>"),
-        ("{{escopo|pt|réptil}}", "<i>(Zoologia)</i>"),
-        ("{{escopo|pt|coloquial|brasil}}", "<i>(coloquial e brasil)</i>"),
         ("{{escopo2|Informática}}", "<i>(Informática)</i>"),
         ("{{escopo2|Brasil|governo}}", "<i>(Brasil)</i>"),
         ("{{escopoCat|Náutica|pt}}", "<i>(Náutica)</i>"),

--- a/wikidict/user_functions.py
+++ b/wikidict/user_functions.py
@@ -230,10 +230,19 @@ def lookup_italic(word: str, locale: str, empty_default: bool = False) -> str:
         'Absolument'
         >>> lookup_italic("inexistant", "fr")
         'inexistant'
+        >>> lookup_italic("alagoas", "pt")
+        'Alagoas'
+        >>> lookup_italic("Antropônimo", "pt")
+        'Antropônimo'
     """
+    default = "" if empty_default else word
+    looking_for = word
+
     if locale == "pt":
-        word = word.lower()
-    return templates_italic[locale].get(word, "" if empty_default else word)
+        looking_for = word.lower()
+        default = word
+
+    return templates_italic[locale].get(looking_for, default)
 
 
 def number(number: str, fsep: str, tsep: str) -> str:


### PR DESCRIPTION
Ex:
- https://pt.wiktionary.org/wiki/Ernestino
- https://pt.wiktionary.org/wiki/relo
- https://pt.wiktionary.org/wiki/pentecostal