### PR TITLE
fix #598: [PR] 'escopoCat' template should make use of the 'escopos' …

### DIFF
--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -152,6 +152,7 @@ def test_parse_word(word, pronunciations, genre, etymology, definitions, page):
         ("{{escopo|pt|coloquial|brasil}}", "<i>(coloquial e brasil)</i>"),
         ("{{escopo2|Informática}}", "<i>(Informática)</i>"),
         ("{{escopo2|Brasil|governo}}", "<i>(Brasil)</i>"),
+        ("{{escopoCat|Árvore|pt}}", "<i>(Botânica)</i>"),
         ("{{escopoCat|Náutica|pt}}", "<i>(Náutica)</i>"),
         ("{{escopoCatLang|Verbo auxiliar|pt}}", "<i>(Verbo auxiliar)</i>"),
         ("{{escopoUso|Portugal|pt}}", "<i>(Portugal)</i>"),

--- a/wikidict/lang/pt/__init__.py
+++ b/wikidict/lang/pt/__init__.py
@@ -71,7 +71,7 @@ templates_multi = {
     # {{escopo2|Brasil|governo}}
     "escopo2": "term(parts[1])",
     # {{escopoCat|Náutica|pt}}
-    "escopoCat": "term(parts[1])",
+    "escopoCat": "term(lookup_italic(parts[1], 'pt'))",
     # {{escopoCatLang|Verbo auxiliar|pt}}
     "escopoCatLang": "term(parts[1])",
     # {{escopoClasseMorfo|variação}}


### PR DESCRIPTION
…list

Ex: https://pt.wiktionary.org/wiki/pau-alaz%C3%A3o