### PR TITLE
fix #592: [FR] Review output of 'couleur' template

### DIFF
--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -376,7 +376,7 @@ def test_parse_word(
         ("{{cf|triner|lang=fr}}", "→ voir <i>triner</i>"),
         ("{{cf|lang=fr|in-|extinguible}}", "→ voir <i>in-</i> et <i>extinguible</i>"),
         ("{{circa|1150}}", "<i>(c. 1150)</i>"),
-        ("{{couleur|#B0F2B6}}", "[RGB #B0F2B6]"),
+        ("{{couleur|#B0F2B6}}", "#B0F2B6"),
         ("{{cours d'eau|fr|de France}}", "<i>(Géographie)</i>"),
         ("{{cours d'eau|fr|de France}}", "<i>(Géographie)</i>"),
         ("{{dénominal de|affection|fr}}", "Dénominal de <i>affection</i>"),

--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -468,7 +468,7 @@ templates_multi = {
     # {{créatures|fr|mythologiques}
     "créatures": "term('Mythologie')",
     # {{couleur|#B0F2B6}}
-    "couleur": "color(parts[1])",
+    "couleur": "parts[1]",
     # {{Deva|[[देव]]|deva|divin}}
     "Deva": "parts[1].strip('[]')",
     # {{déverbal de|haler|fr}}


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/noir_animal