### PR TITLE
fix #611: [SV] Ignore the 'citat' template

### DIFF
--- a/wikidict/lang/__init__.py
+++ b/wikidict/lang/__init__.py
@@ -152,7 +152,7 @@ templates_ignored = {
     "es": es.templates_ignored,
     "fr": fr.templates_ignored,
     "pt": pt.templates_ignored,
-    "sv": defaults.templates_ignored,
+    "sv": sv.templates_ignored,
 }
 
 # Templates that will be completed/replaced using italic style.

--- a/wikidict/lang/sv.py
+++ b/wikidict/lang/sv.py
@@ -32,6 +32,9 @@ sections = (
     "Verbpartikel",
 )
 
+# Templates to ignore: the text will be deleted.
+templates_ignored = ("citat",)
+
 # Templates more complex to manage.
 templates_multi = {
     # {{avledning|sv|mälta|ordform=prespart}}

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -82,7 +82,9 @@ def find_section_definitions(
 
                 # Transform and clean the Wikicode
                 definition = process_templates(word, clean(code), locale)
-                if not definition:
+                # Skip empty definitions
+                # [SV] Skip almost empty definitions
+                if not definition or (locale == "sv" and len(definition) < 2):
                     continue
 
                 # Keep the definition ...


### PR DESCRIPTION
Ex: https://sv.wiktionary.org/wiki/G%C3%B6tet