### PR TITLE
fix #613: [SV] Add support for 'ö' templates

### DIFF
--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -83,6 +83,9 @@ def test_parse_word(word, pronunciations, genre, definitions, page):
         ("{{avledning|sv|mälta|ordform=prespart}}", "<i>presensparticip av</i> mälta"),
         ("{{led|sv|f|gata}}", "<i>förled tillhörigt ordet</i> gata"),
         ("{{led|sv|e|hand}}", "<i>efterled tillhörigt ordet</i> hand"),
+        ("{{ö|en|test}}", "ger: test"),
+        ("{{ö+|en|test}}", "ger: test <sup>(en)</sup>"),
+        ("{{ö-inte|en|test}}", "ger: <b>inte</b> <i><s>test</s></i>"),
         ("{{tagg|historia}}", "<i>(historia)</i>"),
         (
             "{{tagg|kat=nedsättande|text=något nedsättande}}",

--- a/wikidict/lang/sv.py
+++ b/wikidict/lang/sv.py
@@ -44,6 +44,12 @@ templates_multi = {
     "böjning": "italic('böjningsform av') + ' ' + parts[-1]",
     # {{led|sv|f|gata}}
     "led": "italic(('förled' if parts[2] == 'f' else 'efterled') + ' tillhörigt ordet') + ' ' + parts[-1]",
+    # {{ö|en|test}}
+    "ö": 'f"ger: {parts[-1]}"',
+    # {{ö+|en|test}}
+    "ö+": "f\"ger: {parts[-1]} {superscript('(' + parts[1] + ')')}\"",
+    # {{ö-inte|en|test}}
+    "ö-inte": "f\"ger: {strong('inte')} {italic(strike(parts[-1]))}\"",
     # {{tagg|historia}}
     # {{tagg|kat=nedsättande|text=något nedsättande}}
     "tagg": "term(tag(parts[1:]))",

--- a/wikidict/user_functions.py
+++ b/wikidict/user_functions.py
@@ -361,6 +361,16 @@ def small_caps(text: str) -> str:
     return f"<span style='font-variant:small-caps'>{text}</span>"
 
 
+def strike(text: str) -> str:
+    """
+    Return the *text* surrounded by <s> HTML tags.
+
+        >>> strike("foo")
+        '<s>foo</s>'
+    """
+    return f"<s>{text}</s>"
+
+
 def strong(text: str) -> str:
     """
     Return the *text* surrounded by strong HTML tags.
@@ -467,6 +477,7 @@ __all__ = (
     "sentence",
     "small",
     "small_caps",
+    "strike",
     "strong",
     "subscript",
     "superscript",


### PR DESCRIPTION
Added the `strike()` function for the occasion.