### PR TITLE
fix #653: Get the word of the day when no word given to --check-word …

### DIFF
--- a/tests/test_4_check_word.py
+++ b/tests/test_4_check_word.py
@@ -7,6 +7,10 @@ def test_simple():
     assert check_word.main("fr", "vendre") == 0
 
 
+def test_word_of_the_day():
+    assert check_word.main("fr", "") == 0
+
+
 def test_sublist():
     assert check_word.main("fr", "éperon") == 0
 

--- a/tests/test_4_get_word.py
+++ b/tests/test_4_get_word.py
@@ -6,6 +6,10 @@ def test_simple():
     assert get_word.main("fr", "marron") == 0
 
 
+def test_word_of_the_day():
+    assert get_word.main("fr", "") == 0
+
+
 def test_raw():
     assert get_word.main("fr", "marron", raw=True) == 0
 

--- a/wikidict/__main__.py
+++ b/wikidict/__main__.py
@@ -49,7 +49,7 @@ def main() -> int:  # pragma: nocover
 
         return find_templates.main(args["LOCALE"])
 
-    if args["--check-word"]:
+    if args["--check-word"] is not None:
         from . import check_word
 
         return check_word.main(args["LOCALE"], args["--check-word"])
@@ -59,7 +59,7 @@ def main() -> int:  # pragma: nocover
 
         return check_random_words.main(args["LOCALE"], int(args["N"]))
 
-    if args["--get-word"]:
+    if args["--get-word"] is not None:
         from . import get_word
 
         return get_word.main(args["LOCALE"], args["--get-word"], args["--raw"])

--- a/wikidict/check_word.py
+++ b/wikidict/check_word.py
@@ -5,6 +5,7 @@ from functools import partial
 from .render import parse_word
 from .stubs import Word
 from .user_functions import int_to_roman
+from .utils import get_word_of_the_day
 
 import requests
 from bs4 import BeautifulSoup
@@ -88,6 +89,11 @@ def get_wiktionary_page(word: str, locale: str) -> str:
 def main(locale: str, word: str) -> int:
     """Entry point."""
     errors = 0
+
+    # If *word* is empty, get the word of the day
+    if not word:
+        word = get_word_of_the_day(locale)
+
     details = get_word(word, locale)
     if not details.etymology and not details.definitions:
         return errors

--- a/wikidict/get_word.py
+++ b/wikidict/get_word.py
@@ -5,7 +5,7 @@ import requests
 
 from .render import parse_word
 from .user_functions import int_to_roman
-from .utils import convert_pronunciation, convert_genre
+from .utils import convert_pronunciation, convert_genre, get_word_of_the_day
 
 
 def get_and_parse_word(word: str, locale: str, raw: bool = False) -> None:
@@ -61,6 +61,10 @@ def get_and_parse_word(word: str, locale: str, raw: bool = False) -> None:
 
 def main(locale: str, word: str, raw: bool = False) -> int:
     """Entry point."""
+
+    # If *word* is empty, get the word of the day
+    if not word:
+        word = get_word_of_the_day(locale)
 
     get_and_parse_word(word, locale, raw)
     return 0


### PR DESCRIPTION
…or --get-word

Examples:

    $ python -m wikidict fr --check-word ""
    $ python -m wikidict fr --get-word ""

- [x] Fixes #653
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
