### PR TITLE
fix #657: [EN] Add support for the 'glossary' template

### DIFF
--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -270,6 +270,8 @@ def test_parse_word(word, pronunciations, etymology, definitions, page):
             "<i>obsolete emphatic of</i> <b>ye</b>",
         ),
         ("{{gloss|liquid H<sub>2</sub>O}}", "(liquid H<sub>2</sub>O)"),
+        ("{{glossary|inflected}}", "inflected"),
+        ("{{glossary|inflected|Inflected}}", "Inflected"),
         (
             "{{initialism of|en|Inuit Qaujimajatuqangit|nodot=1}}",
             "<i>Initialism of</i> <b>Inuit Qaujimajatuqangit</b>",

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -114,6 +114,8 @@ templates_multi = {
     "en-third-person_singular_of": "italic('Third-person singular simple present indicative form of') + f' {strong(parts[1])}'",  # noqa
     # {{gloss|liquid H<sub>2</sub>O}}
     "gloss": "parenthesis(parts[1])",
+    # {{glossary|inflected}}
+    "glossary": "parts[-1]",
     # {{IPAchar|[tʃ]|lang=en}})
     "IPAchar": "parts[1]",
     # {{IPAfont|[[ʌ]]}}


### PR DESCRIPTION
Ex: https://en.wiktionary.org/wiki/nepoticide

- [x] Fixes #657
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
