### PR TITLE
fix #685: check-word with if word contains subdefinitions

### DIFF
--- a/tests/test_4_check_word.py
+++ b/tests/test_4_check_word.py
@@ -15,6 +15,10 @@ def test_sublist():
     assert check_word.main("fr", "éperon") == 0
 
 
+def test_subsublist():
+    assert check_word.main("fr", "vache") == 0
+
+
 def test_error():
     with patch.object(check_word, "contains", return_value=False):
         assert check_word.main("fr", "42") > 0

--- a/wikidict/check_word.py
+++ b/wikidict/check_word.py
@@ -106,15 +106,21 @@ def main(locale: str, word: str) -> int:
     if details.etymology:
         errors += check(text, details.etymology, " !! Etymology")
 
-    for num, definition in enumerate(details.definitions, start=1):
-        message = f"\n !! Definition n°{num}"
-        if isinstance(definition, str):
+    index = 1
+    for definition in details.definitions:
+        message = f"\n !! Definition n°{index}"
+        if isinstance(definition, tuple):
+            for a, subdef in zip("abcdefghijklmopqrstuvwxz", definition):
+                if isinstance(subdef, tuple):
+                    for rn, subsubdef in enumerate(subdef, 1):
+                        errors += check(
+                            text, subsubdef, f"{message}.{int_to_roman(rn).lower()}"
+                        )
+                else:
+                    errors += check(text, subdef, f"{message}.{a}")
+        else:
             errors += check(text, definition, message)
-            continue
-
-        # Sublist
-        for subnum, subdef in enumerate(definition, start=1):
-            errors += check(text, subdef, f"{message}.{int_to_roman(subnum).lower()}")
+            index += 1
 
     if errors:
         print("\n >>> Errors:", errors)


### PR DESCRIPTION
- [x] Fixes #685
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.