### PR TITLE
fix #690: [FR] 'abreviation' template doesn't have a m option despite doc

### DIFF
--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -556,8 +556,8 @@ templates_multi = {
     "RFC": "sentence(parts)",
     # {{région}}
     # {{région|Lorraine et Dauphiné}}
-    "région": "term(capitalize(parts[1] if len(parts) > 1 else 'régionalisme'))",
-    "régionalisme": "term(capitalize(parts[1] if len(parts) > 1 else 'régionalisme'))",
+    "région": "term(parts[1] if len(parts) > 1 else 'Régionalisme')",
+    "régionalisme": "term(parts[1] if len(parts) > 1 else 'Régionalisme')",
     # {{smcp|Dupont}}
     "smcp": "small_caps(parts[1])",
     # {{SIC}}
@@ -641,8 +641,8 @@ templates_other = {
     "mf?": "<i>masculin ou féminin (l’usage hésite)</i>",
     "mf ?": "<i>masculin ou féminin (l’usage hésite)</i>",
     "minus": "<i>minuscule</i>",
-    "mplur": "<i>masculing pluriel</i>",
-    "msing": "<i>masculing singulier</i>",
+    "mplur": "<i>masculin pluriel</i>",
+    "msing": "<i>masculin singulier</i>",
     "n": "<i>neutre</i>",
     "nombre ?": "Nombre à préciser",
     "note": "<b>Note&nbsp;:</b>",
@@ -668,6 +668,7 @@ templates_other = {
     "tr-dir": "<i>transitif direct</i>",
     "tr-indir": "<i>transitif indirect</i>",
     "usage": "<b>Note d’usage&nbsp;:</b>",
+    "vlatypas-pivot": "v’là-t-i’ pas",
 }
 
 

--- a/wikidict/lang/fr/template_handlers.py
+++ b/wikidict/lang/fr/template_handlers.py
@@ -22,22 +22,17 @@ def render_abreviation(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     '<i>(Abréviation)</i>'
     >>> render_abreviation("abréviation", ["fr"], defaultdict(str))
     '<i>(Abréviation)</i>'
-    >>> render_abreviation("abréviation", ["fr"], defaultdict(str,{"m":"1"}))
-    '<i>(Abréviation)</i>'
-    >>> render_abreviation("abréviation", ["fr"], defaultdict(str, {"de": "dirham marocain", "m": "1"}))
-    'Abréviation de <i>dirham marocain</i>'
     >>> render_abreviation("abréviation", ["fr"], defaultdict(str, {"de": "dirham marocain"}))
-    'abréviation de <i>dirham marocain</i>'
+    'Abréviation de <i>dirham marocain</i>'
     >>> render_abreviation("abréviation", ["fr"], defaultdict(str, {"de": "accusatif", "texte": "'''acc'''usatif"}))
-    "abréviation de <i>'''acc'''usatif</i>"
+    "Abréviation de <i>'''acc'''usatif</i>"
     >>> render_abreviation("abréviation", ["fr"], defaultdict(str, {"de": "accusatif", "texte": "'''acc'''usatif", "nolien": "oui"}))
-    'abréviation de <i>accusatif</i>'
+    'Abréviation de <i>accusatif</i>'
     """  # noqa
     if not parts or not data:
         return italic("(Abréviation)")
 
-    auto_cap = data["m"] in ("1", "oui")
-    phrase = ("A" if auto_cap else "a") + "bréviation"
+    phrase = "Abréviation"
     if data["texte"] and data["nolien"] not in ("1", "oui"):
         phrase += f' de {italic(data["texte"])}'
     elif data["de"]:
@@ -257,6 +252,8 @@ def render_compose_de(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
     'composé de <i>garde</i> et de <i>enfant</i>'
     >>> render_compose_de("composé de", ["élever", "-able", ""], defaultdict(str, {"lang": "fr", "m": "1"}))
     'Dérivé de <i>élever</i> avec le suffixe <i>-able</i>'
+    >>> render_compose_de("composé de", ["litura", "funus"], defaultdict(str, {"lang": "la", "sens1": "", "sens2":"mort au génitif", "sens": ""}))
+    'composé de <i>litura</i> et de <i>funus</i> («&nbsp;mort au génitif&nbsp;»)'
     """  # noqa
 
     # algorithm from https://fr.wiktionary.org/w/index.php?title=Mod%C3%A8le:compos%C3%A9_de&action=edit
@@ -322,7 +319,7 @@ def render_compose_de(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
             phrase += " et le suffixe " + word_tr_sens(
                 parts[2], data.get("tr3", ""), data.get("sens3", "")
             )
-        if "sens" in data:
+        if data["sens"]:
             phrase += f", littéralement «&nbsp;{data['sens']}&nbsp;»"
         return phrase
 
@@ -343,7 +340,7 @@ def render_compose_de(tpl: str, parts: List[str], data: Dict[str, str]) -> str:
             " et de " if len(s_array) < 3 else " et ",
         )
 
-    if "sens" in data:
+    if data["sens"]:
         phrase += f", littéralement «&nbsp;{data['sens']}&nbsp;»"
 
     return phrase


### PR DESCRIPTION
Other misc. fixes. Typo in masculing, 'sens' can be empty in `composé de`, region doesn't capitalize.
New template vlatypas-pivot...

- [x] Fixes #690
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.