### PR TITLE
fix #726: [FR] Improve support for 'unité' template

### DIFF
--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -594,10 +594,6 @@ templates_multi = {
     # {{trad+|conv|Sitophilus granarius}}
     "trad+": "parts[2]",
     "trad-": "parts[2]",
-    # {{unité|92|%}}
-    "unité": "concat(parts[1:], sep=' ')",
-    # {{Unité|60|cm}}
-    "Unité": "concat(parts[1:], sep=' ')",
     # {{variante de|ranche|fr}}
     "variante de": "sentence(parts)",
     "Variante de": "sentence(parts)",

--- a/wikidict/user_functions.py
+++ b/wikidict/user_functions.py
@@ -273,6 +273,11 @@ def number(number: str, fsep: str, tsep: str) -> str:
     # Remove superfluous spaces
     number = number.replace(" ", "")
 
+    # Handle mathematical substract character
+    has_math_substract_symbol = number[0] == "−"
+    if has_math_substract_symbol:
+        number = number.replace("−", "-")
+
     try:
         # Integer
         res = f"{int(number):,}"
@@ -284,7 +289,12 @@ def number(number: str, fsep: str, tsep: str) -> str:
     # then replace the dot with the float separator;
     # and lastly replace the "|" with the deisred thousands separator.
     # This 3-steps-replacement is needed for when separators are replacing each other.
-    return res.replace(",", "|").replace(".", fsep).replace("|", tsep)
+    res = res.replace(",", "|").replace(".", fsep).replace("|", tsep)
+
+    if has_math_substract_symbol:
+        res = res.replace("-", "−")
+
+    return res
 
 
 def parenthesis(text: str) -> str:


### PR DESCRIPTION
Ex: https://fr.wiktionary.org/wiki/trente-deux_pieds

- [x] Fixes #726
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
