### PR TITLE
[EN] Support 'sub' and 'sup' templates (closes #748)

### DIFF
--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -310,6 +310,8 @@ def test_parse_word(word, pronunciations, etymology, definitions, page):
             "{{qualifier|Used only in the plural in the UK}}",
             "(<i>Used only in the plural in the UK</i>)",
         ),
+        ("{{sub|KI}}", "<sub>KI</sub>"),
+        ("{{sup|KI}}", "<sup>KI</sup>"),
         ("{{synonym of|en|drip tip}}", "<i>Synonym of</i> <b>drip tip</b>"),
         (
             "{{taxlink|Gadus macrocephalus|species|ver=170710}}",

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -134,6 +134,10 @@ templates_multi = {
     "qual": "'(' + concat([italic(p) for p in parts[1:]], ', ') + ')'",
     # {{qualifier|Used only ...}}
     "qualifier": "'(' + concat([italic(p) for p in parts[1:]], ', ') + ')'",
+    # {{sub|KI}}
+    "sub": "subscript(parts[1])",
+    # {{sup|KI}}
+    "sup": "superscript(parts[1])",
     # {{taxlink|Gadus macrocephalus|species|ver=170710}}
     "taxlink": "italic(parts[1])",
     # {{vern|Pacific cod}}


### PR DESCRIPTION
Ex: https://en.wiktionary.org/wiki/Elam

- [x] Fixes #748
- [x] Tests added/updated.
- [x] `./check.sh` run and eventual issues fixed.
- [x] Updated CONTRIBUTORS.md, if not already done in the past.
