### PR TITLE
Get back coverage to 100%

### DIFF
--- a/tests/test_3_convert.py
+++ b/tests/test_3_convert.py
@@ -81,6 +81,13 @@ def test_generate_dict(formatter, filename):
             "pron", "gender", "etyl", ["def 1", ["sdef 1", ["ssdef 1"]]], ["baz"]
         ),
         "baz": Word("pron", "gender", "etyl", ["def 1", ["sdef 1"]], ["foobar"]),
+        "etyls": Word(
+            "pron",
+            "gender",
+            ["etyl 1", ["setyl 1"]],
+            ["def 1", ["sdef 1"]],
+            ["foobar"],
+        ),
     }
     variants = defaultdict(str)
     variants["foo"] = ["foobar"]

--- a/tests/test_4_find_templates.py
+++ b/tests/test_4_find_templates.py
@@ -10,3 +10,20 @@ def test_simple():
 def test_no_json_file():
     with patch.object(find_templates, "get_latest_json_file", return_value=None):
         assert find_templates.main("fr") == 1
+
+
+def test_no_sections():
+    words = {"foo": ""}
+    find_templates.find_templates(words, "fr")
+
+
+def test_no_templates():
+    code = "\n".join(
+        """
+== {{langue|conv}} ==
+=== {{S|numéral|conv}} ===
+'''42'''
+""".splitlines()
+    ).strip()
+    words = {"foo": code}
+    find_templates.find_templates(words, "fr")

--- a/tests/test_5_gen_dict.py
+++ b/tests/test_5_gen_dict.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from wikidict import gen_dict
+
+
+def test_simple():
+    output = Path(os.getenv("CWD", "")) / str(uuid4())
+    output.mkdir()
+    try:
+        ret = gen_dict.main("fr", "logiciel", output)
+        assert ret == 0
+    finally:
+        shutil.rmtree(output)
+
+
+def test_multiple():
+    output = Path(os.getenv("CWD", "")) / str(uuid4())
+    output.mkdir()
+    try:
+        ret = gen_dict.main("fr", "base,logiciel", output)
+        assert ret == 0
+    finally:
+        shutil.rmtree(output)


### PR DESCRIPTION
Also improved `--find-templates` by skipping templates of sections. For FR for instance, templates would list all locale sections, which is useless and add noise.
