### PR TITLE
Replace marisa-try-m with marisa-try-ng

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ setuptools>=36.2.1
 beautifulsoup4==4.9.3
 cachetools==4.2.2
 docopt==0.6.2
-marisa_trie_m==0.7.6
+marisa-trie-ng==0.7.6
 mistune==2.0.0rc1  # for DictFile reading
 pillow==8.3.1
 pyglossary==4.0.11


### PR DESCRIPTION
To support all recent Python versions without compilation being required.