### PR TITLE
Fix #1113: [FR] Ignore 'couleurN' template

### DIFF
--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -178,6 +178,7 @@ templates_ignored = (
     "article",
     "Accord des couleurs",
     "ancre",
+    "couleurN",
     "créer-séparément",
     "désabrévier",
     "ébauche-déf",


### PR DESCRIPTION
Not really useful to render the table.
Maybe worth reconsidering when Kobo will be able to output colors :)

Fixes #1113.
