### PR TITLE
Simplify pyglossary command

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Generate dictionary (StarDict)
         run: |
-          pyglossary --no-progress-bar --no-color data/${{ matrix.locale }}/dict-${{ matrix.locale }}.df dict-data.ifo
+          pyglossary --ui=none data/${{ matrix.locale }}/dict-${{ matrix.locale }}.df dict-data.ifo
           zip -r dict-${{ matrix.locale }}.zip dict-data.* res
 
       - name: Upload the dictionary (DictFile)


### PR DESCRIPTION
`pyglossary --ui=none ...` works as intended (for ci / automation) since 4.1.0.

Also you may consider using language codes as part of input file name (like `dict-en-fr.df`) or change the `bookname` manually in `.ifo` file, so that GoldenDict can detect and show the 2 languages.