### PR TITLE
change StarDict bookname to include 2 language codes

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Generate dictionary (StarDict)
         run: |
           pyglossary --ui=none data/${{ matrix.locale }}/dict-${{ matrix.locale }}.df dict-data.ifo
+          sed -i 's/bookname=.*/bookname=dict-${{ matrix.locale }}-${{ matrix.locale }}/' dict-data.ifo
           zip -r dict-${{ matrix.locale }}.zip dict-data.* res
 
       - name: Upload the dictionary (DictFile)


### PR DESCRIPTION
Since StarDict format has no way of defining source and target languages, GoldenDict tries to detect them from `bookname`.
It's just a nice feature of GoldenDict, not a critical thing.

Here is the code that detect language codes:
[https://github.com/goldendict/goldendict/blob/master/langcoder.cc#L328](https://github.com/goldendict/goldendict/blob/8260ac87bac0681b738309a43d3392933562b958/langcoder.cc#L328)

PyGlossary automatically detects 2 language codes from input file name, and adds it to the end of StarDict `bookname`.

But looks like changing format of your `.df` file names requires a lot of changes.
So let's change `bookname` manually for now.