### PR TITLE
Skip coverage 6.3.0 since it blocks tests

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 black==22.1.0
+coverage!=6.3.0
 flake8==4.0.1
 mypy==0.931
 pdoc3==0.10.0


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-cov/issues/520 and https://github.com/nedbat/coveragepy/issues/1310