### PR TITLE
fix #1198: Generate SVG rather than GIF for embedded pictures

### DIFF
--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -2,6 +2,7 @@
 import bz2
 import gzip
 import json
+import re
 import os
 from collections import defaultdict
 from contextlib import suppress
@@ -57,7 +58,18 @@ class KoboBaseFormat(BaseFormat):
     """Base class for Kobo-related dictionaries."""
 
     @staticmethod
-    def create_etymology(etymologies: List[Definitions]) -> str:
+    def choose_image_format(text: str, format: str) -> str:
+        if format == "png":
+            regex = r"src=\"data:image/svg.+?(?=\")\" "
+            text = re.sub(regex, "", text, 0, re.MULTILINE)
+            text = text.replace("data-png", "src")
+        else:
+            regex = r"data-png=\"data:image/png.+?(?=\")\""
+            text = re.sub(regex, "", text, 0, re.MULTILINE)
+        return text
+
+    @staticmethod
+    def create_etymology(etymologies: List[Definitions], format: str = "svg") -> str:
         """Return the HTML code to include for the etymology of a word."""
         result = ""
         if etymologies:
@@ -70,10 +82,11 @@ class KoboBaseFormat(BaseFormat):
                         result += f"<li>{sub_etymology}</li>"
                     result += "</ol>"
             result += "<br />"
+        result = KoboBaseFormat.choose_image_format(result, format)
         return result
 
     @staticmethod
-    def create_definitions(details: Word) -> str:
+    def create_definitions(details: Word, format: str = "svg") -> str:
         """Return the HTML code to include for the definitions of a word."""
         definitions = ""
         for definition in details.definitions:
@@ -89,6 +102,7 @@ class KoboBaseFormat(BaseFormat):
                         definitions += "".join(f"<li>{d}</li>" for d in subdef)
                         definitions += "</ol>"
                 definitions += "</ol>"
+        definitions = KoboBaseFormat.choose_image_format(definitions, format)
         return definitions
 
 
@@ -167,9 +181,13 @@ class KoboFormat(KoboBaseFormat):
         words_snapshot = self.output_dir / "words.snapshot"
         words_count.write_text(str(len(wordlist)))
         words_snapshot.write_text(self.snapshot)
-        to_compress.append(words_count)
-        to_compress.append(words_snapshot)
-        to_compress.append(self.create_install(self.locale, self.output_dir))
+        to_compress.extend(
+            (
+                words_count,
+                words_snapshot,
+                self.create_install(self.locale, self.output_dir),
+            )
+        )
 
         # Pretty print the source
         source = wiktionary[self.locale].format(year=date.today().year)
@@ -292,11 +310,11 @@ class DictFileFormat(KoboBaseFormat):
                 details = Word(*details)
                 if not details.definitions:
                     continue
-                definitions = self.create_definitions(details)
+                definitions = self.create_definitions(details, format="png")
 
                 pronunciation = convert_pronunciation(details.pronunciations)
                 gender = convert_gender(details.gender)
-                etymology = self.create_etymology(details.etymology)
+                etymology = self.create_etymology(details.etymology, format="png")
                 fh.write(f"@ {word}\n")
                 if pronunciation or gender:
                     fh.write(f": {pronunciation.strip()} {gender}\n")


### PR DESCRIPTION
Fixes #1198

This is my current best guess to have SVG in Kobo format but PNG in df (and so in StarDict)... It's ugly and requires applying regex in the convert step...