### PR TITLE
[DE] initial support for variants

### DIFF
--- a/tests/data/de/daß.wiki
+++ b/tests/data/de/daß.wiki
@@ -1,0 +1,2 @@
+== daß ({{Sprache|Deutsch}}) ==
+{{Alte Schreibweise|dass|Reform 1996}}

--- a/tests/data/de/trage.wiki
+++ b/tests/data/de/trage.wiki
@@ -1,0 +1,25 @@
+{{Siehe auch|[[Trage]], [[träge]]}}
+
+== trage ({{Sprache|Deutsch}}) ==
+=== {{Wortart|Konjugierte Form|Deutsch}} ===
+
+{{Nebenformen}}
+:''Imperativ Singular:'' [[trag]]
+
+{{Worttrennung}}
+:tra·ge
+
+{{Aussprache}}
+:{{IPA}} {{Lautschrift|ˈtʁaːɡə}}
+:{{Hörbeispiele}} {{Audio|De-trage.ogg}}
+:{{Reime}} {{Reim|aːɡə|Deutsch}}
+
+{{Grammatische Merkmale}}
+* 1. Person Singular Indikativ Präsens Aktiv des Verbs '''[[tragen]]'''
+* 1. Person Singular Konjunktiv I Präsens Aktiv des Verbs '''[[tragen]]'''
+* 3. Person Singular Konjunktiv I Präsens Aktiv des Verbs '''[[tragen]]'''
+* 2. Person Singular Imperativ Präsens Aktiv des Verbs '''[[tragen]]'''
+
+{{Grundformverweis Konj|tragen}}
+
+{{Ähnlichkeiten 1|[[trabe]], [[träge]]|Anagramme=[[Egart]], [[Ertag]], [[garet]], [[garte]], [[gerat]], [[Grate]], [[raget]], [[ragte]]}}

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -5,7 +5,7 @@ from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions",
+    "word, pronunciations, gender, etymology, definitions, variants",
     [
         (
             "CIA",
@@ -13,6 +13,7 @@ from wikidict.utils import process_templates
             "mf",
             ["Abkürzung von Central Intelligence Agency"],
             ["US-amerikanischer Auslandsnachrichtendienst"],
+            [],
         ),
         (
             "volley",
@@ -24,10 +25,15 @@ from wikidict.utils import process_templates
             [
                 "<i>Sport:</i> aus der Luft (angenommen und direkt kraftvoll abgespielt), ohne dass eine Bodenberührung des Sportgeräts vorher stattgefunden hat",  # noqa
             ],
+            [],
         ),
+        ("trage", ["ˈtʁaːɡə"], "", [], [], ["tragen"]),
+        ("daß", [], "", [], [], ["dass"]),
     ],
 )
-def test_parse_word(word, pronunciations, gender, etymology, definitions, page):
+def test_parse_word(
+    word, pronunciations, gender, etymology, definitions, variants, page
+):
     """Test the sections finder and definitions getter."""
     code = page(word, "de")
     details = parse_word(word, code, "de", force=True)
@@ -35,6 +41,7 @@ def test_parse_word(word, pronunciations, gender, etymology, definitions, page):
     assert gender == details.gender
     assert etymology == details.etymology
     assert definitions == details.definitions
+    assert variants == details.variants
 
 
 @pytest.mark.parametrize(

--- a/wikidict/lang/de/__init__.py
+++ b/wikidict/lang/de/__init__.py
@@ -19,6 +19,8 @@ etyl_section = ("{{Herkunft}}",)
 sections = (
     *etyl_section,
     "{{Bedeutungen}",
+    "{{Grundformverweis ",
+    "{{Alte Schreibweise|",
 )
 
 # Some definitions are not good to keep (plural, gender, ... )
@@ -148,6 +150,16 @@ def last_template_handler(
 
     if lookup_template(template[0]):
         return render_template(template)
+
+    # note: this should be used for variants only
+    if template[0].startswith(
+        (
+            "Grundformverweis ",
+            "Alte Schreibweise",
+        )
+    ):
+        return template[1]
+
     return default(template, locale, word=word)
 
 

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -397,6 +397,27 @@ def parse_word(word: str, code: str, locale: str, force: bool = False) -> Word:
                 variant = process_templates(word, clean(tpl), locale)
                 if variant and variant != word:
                     variants.add(variant)
+        elif locale == "de":
+            if not title.startswith(
+                (
+                    "{{Grundformverweis ",
+                    "{{Alte Schreibweise|",
+                )
+            ):
+                continue
+
+            for tpl in parsed_section[0].templates:
+                tpl = str(tpl)
+                if not tpl.startswith(
+                    (
+                        "{{Grundformverweis ",
+                        "{{Alte Schreibweise|",
+                    )
+                ):
+                    continue
+                variant = process_templates(word, clean(tpl), locale)
+                if variant and variant != word:
+                    variants.add(variant)
 
     return Word(prons, nature, etymology, definitions, sorted(variants))
 


### PR DESCRIPTION
This is an initial support for variants in German. It currently parses three templates, `Grundformverweis Konj`, `Grundformverweis Dekl` and `Alte Schreibweise`, which should handle conjugated verbs, declined words and former spellings.