### PR TITLE
Pronunciations refactoring

### DIFF
--- a/tests/test_2_render.py
+++ b/tests/test_2_render.py
@@ -3,23 +3,6 @@ from unittest.mock import patch
 import pytest
 
 from wikidict import render
-from wikidict.lang import pronunciation
-
-
-@pytest.mark.parametrize(
-    "regexp, code, expected",
-    [
-        (pronunciation["ca"], "{{ca-pron|/as/}}", ["as"]),
-        (pronunciation["ca"], "{{ca-pron|or=/əɫ/}}", ["əɫ"]),
-        (pronunciation["ca"], "{{ca-pron|or=/əɫ/|occ=/eɫ/}}", ["əɫ"]),
-        (pronunciation["ca"], "{{ca-pron|q=àton|or=/əɫ/|occ=/eɫ/|rima=}}", ["əɫ"]),
-        (pronunciation["en"], "{{IPA|en|/ʌs/}}", ["ʌs"]),
-        (pronunciation["en"], "{{IPA|en|/ʌs/}}, {{IPA|en|/ʌz/}}", ["ʌs", "ʌz"]),
-        (pronunciation["en"], "{{IPA|en|/ʌs/|/ʌz/}}", ["ʌs", "ʌz"]),
-    ],
-)
-def test_find_pronunciations(regexp, code, expected):
-    assert render.find_pronunciations(code, regexp) == expected
 
 
 def test_simple():

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -1,7 +1,22 @@
 import pytest
 
+from wikidict.lang.ca import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{ca-pron|/as/}}", ["/as/"]),
+        ("{{ca-pron|or=/əɫ/}}", ["/əɫ/"]),
+        ("{{ca-pron|or=/əɫ/|occ=/eɫ/}}", ["/əɫ/"]),
+        ("{{ca-pron|q=àton|or=/əɫ/|occ=/eɫ/|rima=}}", ["/əɫ/"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +24,7 @@ from wikidict.utils import process_templates
     [
         (
             "-ass-",
-            ["as"],
+            ["/as/"],
             "",
             ["Del sufix <i>-às</i> amb valor augmentatiu."],
             ["Infix que afegeix un matís augmentatiu."],
@@ -25,7 +40,7 @@ from wikidict.utils import process_templates
         ),
         (
             "AFI",
-            ["ˈa.fi"],
+            ["/ˈa.fi/"],
             "",
             ["sigles"],
             [
@@ -95,7 +110,7 @@ from wikidict.utils import process_templates
         ),
         (
             "cas",
-            ["ˈkas"],
+            ["/ˈkas/"],
             "m",
             ["Del llatí <i>casus</i>."],
             [
@@ -181,7 +196,7 @@ from wikidict.utils import process_templates
         ),
         (
             "el",
-            ["əɫ"],
+            ["/əɫ/"],
             "f",
             [],
             [
@@ -200,7 +215,7 @@ from wikidict.utils import process_templates
             ["Cobert per a protegir plantes del vent o del fred extrem."],
         ),
         ("Mn.", [], "", [], ["mossèn com a tractament davant el nom"]),
-        ("PMF", ["ˌpeˈe.məˌe.fə"], "", [], ["Preguntes Més Freqüents."]),
+        ("PMF", ["/ˌpeˈe.məˌe.fə/"], "", [], ["Preguntes Més Freqüents."]),
         ("pen", [], "", [], []),
         (
             "si",

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,7 +1,26 @@
 import pytest
 
+from wikidict.lang.de import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        (
+            ":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}",
+            ["[ˈʁɪndɐˌsteːk]"],
+        ),
+        (
+            ":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}, {{Lautschrift|ˈʁɪndɐˌʃteːk}}, {{Lautschrift|ˈʁɪndɐˌsteɪ̯k}}",
+            ["[ˈʁɪndɐˌsteːk]", "[ˈʁɪndɐˌʃteːk]", "[ˈʁɪndɐˌsteɪ̯k]"],
+        ),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +28,7 @@ from wikidict.utils import process_templates
     [
         (
             "CIA",
-            ["siːaɪ̯ˈɛɪ̯"],
+            ["[siːaɪ̯ˈɛɪ̯]"],
             "mf",
             ["Abkürzung von Central Intelligence Agency"],
             ["US-amerikanischer Auslandsnachrichtendienst"],
@@ -17,7 +36,7 @@ from wikidict.utils import process_templates
         ),
         (
             "volley",
-            ["ˈvɔli", "ˈvɔle", "ˈvɔlɛɪ̯"],
+            ["[ˈvɔli]", "[ˈvɔle]", "[ˈvɔlɛɪ̯]"],
             "",
             [
                 "Dem seit 1960 im Duden lexikalisierten Wort liegt die englische Kollokation <i>at/on the <i>volley</i></i> ‚aus der Luft‘ zugrunde.",  # noqa
@@ -27,7 +46,7 @@ from wikidict.utils import process_templates
             ],
             [],
         ),
-        ("trage", ["ˈtʁaːɡə"], "", [], [], ["tragen"]),
+        ("trage", ["[ˈtʁaːɡə]"], "", [], [], ["tragen"]),
         ("daß", [], "", [], [], ["dass"]),
     ],
 )

--- a/tests/test_el.py
+++ b/tests/test_el.py
@@ -1,7 +1,20 @@
 import pytest
 
+from wikidict.lang.el import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{ΔΦΑ|tɾeˈlos|γλ=el}}", ["tɾeˈlos"]),
+        ("{{ΔΦΑ|γλ=el|ˈni.xta}}", ["ˈni.xta"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -1,7 +1,23 @@
 import pytest
 
+from wikidict.lang.en import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{IPA|en|/ʌs/}}", ["/ʌs/"]),
+        ("{{IPA|en|/ʌs/|/ʌs/}}", ["/ʌs/"]),
+        ("{{IPA|en|/ʌs/}} {{IPA|en|/ʌs/}}", ["/ʌs/"]),
+        ("{{IPA|en|/ʌs/}}, {{IPA|en|/ʌz/}}", ["/ʌs/", "/ʌz/"]),
+        ("{{IPA|en|/ʌs/|/ʌz/}}", ["/ʌs/", "/ʌz/"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +25,7 @@ from wikidict.utils import process_templates
     [
         (
             "ab",
-            ["æb"],
+            ["/æb/"],
             ["Abbreviation of <b>abdominal</b> <b>muscles</b>."],
             [
                 "<i>(informal)</i> abdominal muscle. <small>[Mid 20<sup>th</sup> century.]</small>",
@@ -23,7 +39,7 @@ from wikidict.utils import process_templates
         ),
         (
             "cum",
-            ["kʌm", "kʊm"],
+            ["/kʌm/", "/kʊm/"],
             ["Learned borrowing from Latin <i>cum</i> (“with”)."],
             [
                 "<i>Used in indicating a thing with two roles, functions, or natures, or a thing that has changed from one to another.</i>",  # noqa
@@ -39,7 +55,7 @@ from wikidict.utils import process_templates
         ),
         (
             "efficient",
-            ["ɪˈfɪʃənt"],
+            ["/ɪˈfɪʃənt/", "/əˈfɪʃənt/"],
             [
                 "1398, “making,” from Old French, from Latin <i>efficientem</i>, nominative <i>efficiēns</i>, participle of <i>efficere</i> (“work out, accomplish”) (see <b>effect</b>). Meaning “productive, skilled” is from 1787. <i>Efficiency apartment</i> is first recorded 1930, American English."  # noqa
             ],
@@ -53,7 +69,7 @@ from wikidict.utils import process_templates
         ),
         (
             "it's",
-            ["ɪts"],
+            ["/ɪts/"],
             ["Contraction of ‘it is’ or ‘it has’."],
             [
                 "<i>Contraction of</i> <b>it is</b>.",
@@ -65,7 +81,7 @@ from wikidict.utils import process_templates
         ),
         (
             "Mars",
-            ["ˈmɑːz"],
+            ["/ˈmɑːz/", "/ˈmɑɹz/"],
             [
                 "From Middle English <i>Mars</i>, from Latin <i>Mārs</i> (“god of war”), from older Latin (older than 75 <small>B.C.E.</small>) <i>Māvors</i>. <i>𐌌𐌀𐌌𐌄𐌓𐌔</i> was his Oscan name. He was also known as <i>Marmor</i>, <i>Marmar</i> and <i>Maris</i>, the latter from the Etruscan deity Maris."  # noqa
             ],
@@ -79,7 +95,7 @@ from wikidict.utils import process_templates
         ),
         (
             "portmanteau",
-            ["pɔːtˈmæn.təʊ"],
+            ["/pɔːtˈmæn.təʊ/", "/pɔːɹtˈmæntoʊ/", "/ˌpɔːɹtmænˈtoʊ/"],
             [
                 "Middle French <i>portemanteau</i> (“coat stand”), from <i>porte</i> (“carry”) + <i>manteau</i> (“coat”)."  # noqa
             ],
@@ -95,7 +111,7 @@ from wikidict.utils import process_templates
         ),
         (
             "someone",
-            ["ˈsʌmwʌn"],
+            ["/ˈsʌmwʌn/"],
             ["From <i>some</i>&nbsp;+&nbsp;<i>one</i>."],
             [
                 "some person.",
@@ -105,7 +121,7 @@ from wikidict.utils import process_templates
         ),
         (
             "the",
-            ["ˈðiː"],
+            ["/ˈðiː/", "/ˈðʌ/", "/ði/", "/ðɪ/", "/ðə/"],
             [
                 "From Middle English <i>þe</i>, from Old English <i>þē</i> <i>m</i> (“the, that”, demonstrative pronoun), a late variant of <i>sē</i>, the <i>s-</i> (which occurred in the masculine and feminine nominative singular only) having been replaced by the <i>þ-</i> from the oblique stem.",  # noqa
                 "Originally neutral nominative, in Middle English it superseded all previous Old English nominative forms (<i>sē</i> <i>m</i>, <i>sēo</i> <i>f</i>, <i>þæt</i> <i>n</i>, <i>þā</i> <i>p</i>); <i>sē</i> is from Proto-West Germanic <i>*siz</i>, from Proto-Germanic <i>*sa</i>, ultimately from Proto-Indo-European <i>*só</i>.",  # noqa
@@ -129,7 +145,7 @@ from wikidict.utils import process_templates
         ),
         (
             "um",
-            ["ʌm", "əːm"],
+            ["/ʌm/", "/əːm/"],
             ["Onomatopoeic."],
             [
                 "<i>Expression of hesitation, uncertainty or space filler in conversation</i>. See uh.",
@@ -141,7 +157,7 @@ from wikidict.utils import process_templates
         ),
         (
             "us",
-            ["ʌs", "ʌz"],
+            ["/ʌs/", "/ʌz/", "/əs/", "/əz/"],
             [
                 "From Middle English <i>us</i>, from Old English <i>ūs</i> (“us”, dative personal pronoun), from Proto-Germanic <i>*uns</i> (“us”), from Proto-Indo-European <i>*ne-</i>, <i>*nō-</i>, <i>*n-ge-</i>, <i>*n̥smé</i> (“us”). Cognate with Saterland Frisian <i>uus</i> (“us”), West Frisian <i>us</i>, <i>ús</i> (“us”), Low German <i>us</i> (“us”), Dutch <i>ons</i> (“us”), German <i>uns</i> (“us”), Danish <i>os</i> (“us”), Latin <i>nōs</i> (“we, us”)."  # noqa
             ],
@@ -157,7 +173,17 @@ from wikidict.utils import process_templates
         ),
         (
             "water",
-            ["ˈwɔːtə"],
+            [
+                "/ˈwɔːtə/",
+                "/ˈwɔtər/",
+                "/ˈwɒtə/",
+                "/ˈwɒtəɹ/",
+                "/ˈwɔtəɹ/",
+                "/ˈwɑtəɹ/",
+                "/ˈwʊtəɹ/",
+                "/ˈwoːtə/",
+                "/ˈwætəɹ/",
+            ],
             [
                 "From Middle English <i>water</i>, from Old English <i>wæter</i> (“water”), from Proto-West Germanic <i>*watar</i>, from Proto-Germanic <i>*watōr</i> (“water”), from Proto-Indo-European <i>*wódr̥</i> (“water”).",  # noqa
                 "Cognate with cf, North Frisian <i>weeter</i> (“water”), Saterland Frisian <i>Woater</i> (“water”), West Frisian <i>wetter</i> (“water”), Dutch <i>water</i> (“water”), Low German <i>Water</i> (“water”), German <i>Wasser</i>, Old Norse <i>vatn</i> (Swedish <i>vatten</i> (“water”), Danish <i>vand</i> (“water”), Norwegian Bokmål <i>vann</i> (“water”), Norwegian Nynorsk and Icelandic <i>vatn</i> (“water”)), Old Irish <i>coin fodorne</i> (“otters”, literally “water-dogs”), Latin <i>unda</i> (“wave”), Lithuanian <i>vanduõ</i> (“water”), Russian <i>вода́</i> (<i>voda</i>, “water”), Albanian <i>ujë</i> (“water”), Ancient Greek <i>ὕδωρ</i> (“water”), Armenian <i>գետ</i> (<i>get</i>, “river”), Sanskrit <i>उदन्</i> (<i>udán</i>, “wave, water”), Hittite <i>𒉿𒀀𒋻</i> (<i>wa-a-tar</i>).",  # noqa
@@ -198,7 +224,7 @@ from wikidict.utils import process_templates
         ),
         (
             "word",
-            ["wɜːd"],
+            ["/wɜːd/", "/wɝd/"],
             [
                 "From Middle English <i>word</i>, from Old English <i>word</i>, from Proto-West Germanic <i>*word</i>, from Proto-Germanic <i>*wurdą</i>, from Proto-Indo-European <i>*wr̥dʰh₁om</i>. Doublet of <i>verb</i> and <i>verve</i>; further related to <b>vrata</b>."  # noqa
             ],

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -1,7 +1,23 @@
 import pytest
 
+from wikidict.lang.es import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{pron-graf|fone=ˈa.t͡ʃo}}", ["[ˈa.t͡ʃo]"]),
+        (
+            "{{pron-graf|pron=seseo|altpron=No seseante|fone=ˈgɾa.θjas|2pron=seseo|alt2pron=Seseante|2fone=ˈgɾa.sjas|audio=Gracias (español).ogg}}",  # noqa
+            ["[ˈgɾa.θjas]", "[ˈgɾa.sjas]"],
+        ),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +25,7 @@ from wikidict.utils import process_templates
     [
         (
             "-acho",
-            ["ˈa.t͡ʃo"],
+            ["[ˈa.t͡ʃo]"],
             ["Del latín <i>-acĕus</i>. De allí también <i>-áceo</i>."],
             [
                 "<i>Forma aumentativos, a veces despectivos, a partir de adjetivos y sustantivos</i>.",
@@ -28,7 +44,7 @@ from wikidict.utils import process_templates
         ),
         (
             "comer",
-            ["koˈmeɾ"],
+            ["[koˈmeɾ]"],
             [
                 'Del latín <i>comedĕre</i>, infinitivo de <i>comedō</i> ("devorar"), formado a partir <i>cum</i> ("con") y <i>edō</i> ("comer").'  # noqa
             ],
@@ -47,7 +63,7 @@ from wikidict.utils import process_templates
         ),
         (
             "es decir",
-            ["es.ðeˈθiɾ"],
+            ["[es.ðeˈθiɾ]"],
             [],
             [
                 "<i>Úsase para introducir una aclaración, explicación o definición de lo precedente</i>",
@@ -56,7 +72,7 @@ from wikidict.utils import process_templates
         ),
         (
             "entrada",
-            ["en̪ˈtɾa.ða"],
+            ["[en̪ˈtɾa.ða]"],
             [
                 "De <i>entrado</i> (<i>participio de <i>entrar</i></i>) y el sufijo flexivo <i>-a</i> para el femenino."
             ],
@@ -96,7 +112,7 @@ from wikidict.utils import process_templates
         ),
         (
             "extenuado",
-            ["eks.teˈnwa.ðo"],
+            ["[eks.teˈnwa.ðo]"],
             [],
             [
                 "Cansado, debilitado.",
@@ -106,7 +122,7 @@ from wikidict.utils import process_templates
         ),
         (
             "futuro",
-            ["fuˈtu.ɾo"],
+            ["[fuˈtu.ɾo]"],
             [
                 'Del latín <i>futūrus</i>, participio activo futuro irregular de <i>esse</i> ("ser"), y este el protoindoeuropeo <i>*bhū-</i>, <i>*bʰew-</i> ("existir", "llegar a ser").'  # noqa
             ],
@@ -120,7 +136,7 @@ from wikidict.utils import process_templates
         ),
         (
             "gracias",
-            ["ˈgɾa.θjas", "ˈgɾa.sjas"],
+            ["[ˈgɾa.θjas]", "[ˈgɾa.sjas]"],
             [],
             [
                 "<i>Úsase para expresar agradecimiento</i>.",
@@ -130,7 +146,7 @@ from wikidict.utils import process_templates
         ),
         (
             "hasta",
-            ["ˈas.ta"],
+            ["[ˈas.ta]"],
             [
                 'Del castellano antiguo <i>fasta</i>, del más antiguo <i>hata</i>, <i>fata</i>, quizá préstamo del árabe <i>حتى</i> (<i>ḥatta</i>), o del latín <i>ad</i> ("a") <i>ista</i> ("esta"), o de ambos.'  # noqa
             ],
@@ -180,7 +196,7 @@ from wikidict.utils import process_templates
         ),
         (
             "también",
-            ["tamˈbjen"],
+            ["[tamˈbjen]"],
             ["Compuesto de <i>tan</i> y <i>bien</i>"],
             [
                 "<i>Utilizado para especificar que una o varias cosas son similares, o que comparten atributos con otra previamente nombrada</i>.",  # noqa
@@ -190,7 +206,7 @@ from wikidict.utils import process_templates
         ),
         (
             "uni-",
-            ["ˈu.ni"],
+            ["[ˈu.ni]"],
             ['Del latín <i>uni-</i>, de <i>unus</i> ("uno")'],
             [
                 "<i>Elemento compositivo que significa</i> uno. un único, relativo a uno solo.",

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -1,7 +1,20 @@
 import pytest
 
+from wikidict.lang.fr import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{pron|ɑ|fr}}", ["\\ɑ\\"]),
+        ("{{pron|ɑ|fr}}, {{pron|a|fr}}", ["\\ɑ\\", "\\a\\"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +22,7 @@ from wikidict.utils import process_templates
     [
         (
             "-eresse",
-            ["(ə).ʁɛs"],
+            ["\\(ə).ʁɛs\\"],
             "f",
             [
                 "<i>(Date à préciser)</i> Ce suffixe est né d’une coupe erronée du suffixe des mots comme <i>enchanteresse</i> et <i>pécheresse</i>. En effet, ces derniers sont en fait le cas sujet de mots en <i>-eur</i> auquel on a ajouté le suffixe féminisant <i>-esse</i> sous le schéma suivant :",  # noqa
@@ -24,7 +37,7 @@ from wikidict.utils import process_templates
         ),
         (
             "a",
-            ["ɑ", "a"],
+            ["\\ɑ\\", "\\a\\"],
             "m",
             [],
             [
@@ -41,7 +54,7 @@ from wikidict.utils import process_templates
         ),
         (
             "π",
-            ["p"],
+            [],
             "",
             [],
             [
@@ -52,7 +65,7 @@ from wikidict.utils import process_templates
         ),
         (
             "42",
-            ["ka.ʁɑ̃t.dø"],
+            ["\\ka.ʁɑ̃t.dø\\"],
             "msing",
             [],
             [
@@ -67,7 +80,7 @@ from wikidict.utils import process_templates
         ),
         (
             "accueil",
-            ["a.kœj"],
+            ["\\a.kœj\\"],
             "m",
             ["<u><i>(XII<sup>e</sup> siècle)</i> Déverbal de <i>accueillir</i>.</u>"],
             [
@@ -81,7 +94,7 @@ from wikidict.utils import process_templates
         ),
         (
             "acrologie",
-            ["a.kʁɔ.lɔ.ʒi"],
+            ["\\a.kʁɔ.lɔ.ʒi\\"],
             "f",
             [
                 "Du grec ancien ἄκρος, <i>akros</i> («&nbsp;extrémité&nbsp;»), voir <i>acro-</i>, avec le suffixe <i>-logie</i>."  # noqa
@@ -96,7 +109,7 @@ from wikidict.utils import process_templates
         ),
         (
             "aux",
-            ["o"],
+            ["\\o\\"],
             "mf",
             [],
             [
@@ -107,7 +120,7 @@ from wikidict.utils import process_templates
         ),
         (
             "base",
-            ["bɑz"],
+            ["\\bɑz\\"],
             "f",
             [
                 "<i>(Date à préciser)</i> Du latin <i>basis</i> («&nbsp;id.&nbsp;»), du grec ancien βάσις, <i>básis</i> («&nbsp;marche&nbsp;»)."  # noqa
@@ -145,7 +158,7 @@ from wikidict.utils import process_templates
         ),
         (
             "bath",
-            ["bat"],
+            ["\\bat\\"],
             "m",
             [
                 "(<i>Adjectif, nom 1</i>) <i>(1846)</i> Origine discutée :",
@@ -166,7 +179,7 @@ from wikidict.utils import process_templates
         ),
         (
             "Bogotanais",
-            ["bɔ.ɡɔ.ta.nɛ"],
+            ["\\bɔ.ɡɔ.ta.nɛ\\"],
             "m",
             ["Du nom Bogota avec le préfixe -ais."],
             [],
@@ -174,7 +187,7 @@ from wikidict.utils import process_templates
         ),
         (
             "colligeait",
-            ["kɔ.li.ʒɛ"],
+            ["\\kɔ.li.ʒɛ\\"],
             "",
             [],
             [],
@@ -182,7 +195,7 @@ from wikidict.utils import process_templates
         ),
         (
             "corps portant",
-            ["kɔʁ pɔʁ.tɑ̃"],
+            ["\\kɔʁ pɔʁ.tɑ̃\\"],
             "m",
             ["Locution composée de <i>corps</i> et de <i>portant</i>."],
             [
@@ -193,7 +206,7 @@ from wikidict.utils import process_templates
         ),
         (
             "DES",
-            ["deː,ʔeː,ʔɛs"],
+            [],
             "m",
             [
                 "<i>(Commerce international)</i> <i>(1936)</i> Terme créé par la Chambre de commerce internationale. Sigle de l’anglais <i>delivered ex ship</i>; « rendu par navire »."  # noqa
@@ -212,7 +225,7 @@ from wikidict.utils import process_templates
         ),
         (
             "dubitatif",
-            ["dy.bi.ta.tif"],
+            ["\\dy.bi.ta.tif\\"],
             "",
             ["Du latin <i>dubitativus</i>."],
             [
@@ -223,7 +236,7 @@ from wikidict.utils import process_templates
         ),
         (
             "effluve",
-            ["e.flyv"],
+            ["\\e.flyv\\"],
             "mf",
             [
                 "Du latin <i>effluvium</i>, du préfixe <i>ex-</i> indiquant la séparation et de <i>fluxus</i> (« écoulement »)."  # noqa
@@ -236,7 +249,7 @@ from wikidict.utils import process_templates
         ),
         (
             "employer",
-            ["ɑ̃.plwa.je"],
+            ["\\ɑ̃.plwa.je\\"],
             "",
             ["Du latin <i>implicāre</i> («&nbsp;impliquer&nbsp;»)."],
             [
@@ -248,7 +261,7 @@ from wikidict.utils import process_templates
         ),
         (
             "encyclopædie",
-            ["ɑ̃.si.klɔ.pe.di"],
+            ["\\ɑ̃.si.klɔ.pe.di\\"],
             "f",
             ["→ voir <i>encyclopédie</i>"],
             ["<i>(Archaïsme)</i> <i>Variante orthographique de</i> encyclopédie."],
@@ -256,7 +269,7 @@ from wikidict.utils import process_templates
         ),
         (
             "éperon",
-            ["e.pʁɔ̃"],
+            ["\\e.pʁɔ̃\\"],
             "m",
             ["De l’ancien français <i>esperon</i>, du vieux-francique *<i>sporo</i>."],
             [
@@ -276,7 +289,7 @@ from wikidict.utils import process_templates
         ),
         (
             "greffier",
-            ["ɡʁɛ.fje", "ɡʁe.fje"],
+            ["\\ɡʁɛ.fje\\", "\\ɡʁe.fje\\"],
             "m",
             [
                 "(<i>Nom commun 1</i>) <i>(Date à préciser)</i> Du latin <i>graphiarius</i> («&nbsp;d’écriture, de style, de poinçon&nbsp;») ou dérivé de <i>greffe</i>, avec le suffixe <i>-ier</i>.",  # noqa
@@ -293,7 +306,7 @@ from wikidict.utils import process_templates
         ),
         (
             "ich",
-            ["ɪç"],
+            [],
             "",
             [],
             ["<i>(Linguistique)</i> Code ISO 639-3 de l’etkywan."],
@@ -301,7 +314,7 @@ from wikidict.utils import process_templates
         ),
         (
             "koro",
-            ["kɔ.ʁo"],
+            ["\\kɔ.ʁo\\"],
             "m",
             [],
             [
@@ -313,7 +326,7 @@ from wikidict.utils import process_templates
         ),
         (
             "mutiner",
-            ["my.ti.ne"],
+            ["\\my.ti.ne\\"],
             "",
             ["Dénominal de <i>mutin</i>."],
             [
@@ -325,7 +338,7 @@ from wikidict.utils import process_templates
         ),
         (
             "naguère",
-            ["na.ɡɛʁ"],
+            ["\\na.ɡɛʁ\\"],
             "",
             ["De <i>il n’y a guère</i> (de temps). Voir aussi <i>na</i>."],
             [
@@ -338,7 +351,7 @@ from wikidict.utils import process_templates
         # The etymology never pass?!
         # (
         #     "pinyin",
-        #     ["pin.jin"],
+        #     ["\\pin.jin\\"],
         #     "m",
         #     "<i>(Nom 1)</i> (Vers 1950) Du chinois 拼音, <i>pīnyīn</i>, formé de 拼 <i>pīn</i> (« épeler ») et de 音 <i>yīn</i> (« son »), donc «\xa0épeler les sons\xa0».",  # noqa
         #     [
@@ -349,7 +362,7 @@ from wikidict.utils import process_templates
         # ),
         (
             "précepte",
-            ["pʁe.sɛpt"],
+            ["\\pʁe.sɛpt\\"],
             "m",
             [
                 "Emprunté au latin <i>praeceptum</i> («&nbsp;précepte, leçon, règle&nbsp;»), dérivé de <i>praecipere</i> signifiant « prendre avant, prendre le premier » ou encore « recommander », « conseiller », « prescrire »."  # noqa
@@ -364,7 +377,7 @@ from wikidict.utils import process_templates
         ),
         (
             "rance",
-            ["ʁɑ̃s"],
+            ["\\ʁɑ̃s\\"],
             "mf",
             ["Du latin <i>rancidus</i> par l’intermédiaire de l’ancien occitan."],
             [
@@ -377,7 +390,7 @@ from wikidict.utils import process_templates
         ),
         (
             "sapristi",
-            ["sa.pʁis.ti"],
+            ["\\sa.pʁis.ti\\"],
             "",
             ["Déformation de <i>sacristi</i>, afin de ne pas blasphémer ouvertement."],
             ["Pour marquer l’étonnement."],
@@ -385,7 +398,7 @@ from wikidict.utils import process_templates
         ),
         (
             "silicone",
-            ["si.li.kon"],
+            ["\\si.li.kon\\"],
             "f",
             [
                 "<i>(1863)</i> De l’allemand <i>Silikon</i>, mot créé par Friedrich Wöhler et, pour les équivalents français du mot allemand, dérivé de <i>silicium</i>, avec le suffixe <i>-one</i>."  # noqa
@@ -401,7 +414,7 @@ from wikidict.utils import process_templates
         ),
         (
             "suis",
-            ["sɥi"],
+            ["\\sɥi\\"],
             "",
             [
                 "<i>(Forme de verbe 1)</i> De l’ancien français <i>suis</i> (forme du verbe <i>estre</i>), lui-même issu du latin <i>sum</i> (forme du verbe <i>esse</i>)."  # noqa
@@ -411,7 +424,7 @@ from wikidict.utils import process_templates
         ),
         (
             "Turgeon",
-            ["tyʁ.ʒɔ̃"],
+            ["\\tyʁ.ʒɔ̃\\"],
             "",
             [
                 "Nom en rapport avec l’esturgeon «&nbsp;Turgeon&nbsp;» dans Jean <span style='font-variant:small-caps'>Tosti</span>, <i>Les noms de famille</i>."  # noqa

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,7 +1,19 @@
 import pytest
 
+from wikidict.lang.it import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{IPA|/kondiˈvidere/}}", ["/kondiˈvidere/"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -9,7 +21,7 @@ from wikidict.utils import process_templates
     [
         (
             "condividere",
-            ["kondiˈvidere"],
+            ["/kondiˈvidere/"],
             "",
             [
                 "dal latino <i>cum</i> e <i>dividere</i>; l'attuale uso improprio del verbo <i>condividere</i> è dovuto alla diffusione dei social network negli anni 2000 e 2010",  # noqa
@@ -24,7 +36,7 @@ from wikidict.utils import process_templates
         ),
         (
             "debolmente",
-            ["debolˈmente"],
+            ["/debolˈmente/"],
             "",
             ["composto dall'aggettivo debole e dal suffisso -mente"],
             [
@@ -33,7 +45,7 @@ from wikidict.utils import process_templates
         ),
         (
             "lettore",
-            ["letˈtore"],
+            ["/letˈtore/"],
             "m",
             ['dal latino <i>lector</i>, derivazione di <i>legĕre</i> ossia "leggere"'],
             [

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -1,18 +1,7 @@
 import pytest
 
-from wikidict.lang.no import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
-
-
-@pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_no.py
+++ b/tests/test_no.py
@@ -1,7 +1,18 @@
 import pytest
 
+from wikidict.lang.no import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -1,7 +1,20 @@
 import pytest
 
+from wikidict.lang.pt import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{AFI|/pɾe.ˈno.me̝/}}", ["/pɾe.ˈno.me̝/"]),
+        ("{{AFI|/pɾe.ˈno.me̝/|lang=pt}}", ["/pɾe.ˈno.me̝/"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -10,14 +23,14 @@ from wikidict.utils import process_templates
         ("ababalhar", [], "", ["De baba."], ["<i>(popular)</i> babar; conspurcar"]),
         (
             "alguém",
-            ["aw.ˈgẽj"],
+            ["/aɫ.ˈɡɐ̃j̃/"],
             "",
             ["Do latim <i>alĭquem</i> <sup>(la)</sup>."],
             ["pessoa não identificada"],
         ),
         (
             "algo",
-            [],
+            ["/ˈaɫ.ɡu/"],
             "",
             [],
             ["um pouco, de certo modo", "objeto (não-identificado) de que se fala"],
@@ -46,7 +59,7 @@ from wikidict.utils import process_templates
         ),
         (
             "COPOM",
-            [],
+            ["/ko.ˈpõ/"],
             "m",
             [],
             [
@@ -56,7 +69,7 @@ from wikidict.utils import process_templates
         ),
         (
             "dezassete",
-            [],
+            ["/dɨ.zɐ.ˈsɛ.tɨ/"],
             "",
             ["Contração do latim vulgar <i>decem</i> + <i>ac</i> + <i>septem</i>."],
             [
@@ -99,7 +112,13 @@ from wikidict.utils import process_templates
                 "<b>Nota:</b> Liga-se por hífen ao morfema seguinte quando este começa por <b>vogal</b>, <b>h</b>, <b>r</b> ou <b>s</b>.",  # noqa
             ],
         ),
-        ("para", [], "", [], ["exprime fim, destino, lugar, tempo, direção etc"]),
+        (
+            "para",
+            ["/ˈpɐ.ɾɐ/"],
+            "",
+            [],
+            ["exprime fim, destino, lugar, tempo, direção etc"],
+        ),
         (
             "paulista",
             [],

--- a/tests/test_ru.py
+++ b/tests/test_ru.py
@@ -1,7 +1,23 @@
 import pytest
 
+from wikidict.lang.ru import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        # Execpeted behaviour after #1376
+        # (
+        #     "{{transcriptions-ru|страни́ца|страни́цы|Ru-страница.ogg}}",
+        #     ["[strɐˈnʲit͡sə]"],
+        # ),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -1,7 +1,19 @@
 import pytest
 
+from wikidict.lang.sv import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("", []),
+        ("{{uttal|sv|ipa=eːn/, /ɛn/, /en}}", ["/eːn/, /ɛn/, /en/"]),
+    ],
+)
+def test_find_pronunciations(code, expected):
+    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(
@@ -10,7 +22,7 @@ from wikidict.utils import process_templates
         ("auto", [], ["automatisk; självgående", "automatiskt läge", "autostart"]),
         (
             "en",
-            ["eːn/, /ɛn/, /en"],
+            ["/eːn/, /ɛn/, /en/"],
             [
                 "ungefär; omkring",
                 "obestämd artikel singular utrum",
@@ -33,7 +45,7 @@ from wikidict.utils import process_templates
         ),
         (
             "min",
-            ["mɪn"],
+            ["/mɪn/", "/miːn/"],
             [
                 "possessivt pronomen som indikerar ägande av eller tillhörighet till den talande (jag) om det ägda eller tillhörande är i ental och har n-genus; possessivt pronomen i första person singular med huvudordet i singular utrum",  # noqa
                 "ovanstående i självständig form",
@@ -46,7 +58,7 @@ from wikidict.utils import process_templates
         ("og", [], []),
         (
             "sand",
-            ["sand"],
+            ["/sand/"],
             [
                 "sten som blivit till små korn, antingen genom väder och vind eller på konstgjord väg",
                 "<i>(geologi)</i> jordart med kornstorlek mellan 0,06 och 2 mm",

--- a/wikidict/find_templates.py
+++ b/wikidict/find_templates.py
@@ -11,7 +11,8 @@ from .render import find_all_sections, find_sections, get_latest_json_file, load
 
 def find_titles(code: str, locale: str) -> List[str]:
     """Find the correct section(s) holding the current locale definition(s)."""
-    return [title for title, _ in find_all_sections(code, locale)]
+    _, all_sections = find_all_sections(code, locale)
+    return [title for title, _ in all_sections]
 
 
 def find_templates(in_words: Dict[str, str], locale: str) -> None:
@@ -22,7 +23,7 @@ def find_templates(in_words: Dict[str, str], locale: str) -> None:
         for title in find_titles(code, locale):
             found_sections[title].append(in_word)
 
-        parsed_sections = find_sections(code, locale)
+        _, parsed_sections = find_sections(code, locale)
         defs = "\n".join(str(s) for s in parsed_sections.values())
         for template in re.findall(r"({{[^{}]*}})", defs):
             if template.startswith(locale_sections):

--- a/wikidict/lang/__init__.py
+++ b/wikidict/lang/__init__.py
@@ -75,8 +75,8 @@ def _populate(
     }
 
 
-# Regex to find the pronunciation
-pronunciation: Dict[str, Pattern[str]] = _populate("pronunciation", callback=re.compile)
+# Function to find the pronunciation
+pronunciation = _populate("find_pronunciations")
 
 # Regex to find the gender
 gender: Dict[str, Pattern[str]] = _populate("gender", callback=re.compile)
@@ -136,7 +136,7 @@ templates_multi: Dict[str, Dict[str, str]] = _populate("templates_multi")
 templates_other: Dict[str, Dict[str, str]] = _populate("templates_other")
 
 # When a template is not handled by any previous template handlers,
-# this method will be called with *parts* as argument.
+# this function will be called with *parts* as argument.
 last_template_handler = _populate("last_template_handler")
 
 # The full release description on GitHub:

--- a/wikidict/lang/__init__.py
+++ b/wikidict/lang/__init__.py
@@ -75,9 +75,6 @@ def _populate(
     }
 
 
-# Function to find the pronunciation
-pronunciation = _populate("find_pronunciations")
-
 # Regex to find the gender
 gender: Dict[str, Pattern[str]] = _populate("gender", callback=re.compile)
 
@@ -135,13 +132,16 @@ templates_multi: Dict[str, Dict[str, str]] = _populate("templates_multi")
 # Templates that will be completed/replaced using custom style.
 templates_other: Dict[str, Dict[str, str]] = _populate("templates_other")
 
-# When a template is not handled by any previous template handlers,
-# this function will be called with *parts* as argument.
-last_template_handler = _populate("last_template_handler")
-
 # The full release description on GitHub:
 # https://github.com/BoboTiG/ebook-reader-dict/releases/tag/$LOCALE
 release_description: Dict[str, str] = _populate("release_description")
 
 # Dictionary name that will be printed below each definition
 wiktionary: Dict[str, str] = _populate("wiktionary")
+
+# Function to find the pronunciation
+find_pronunciations = _populate("find_pronunciations")
+
+# When a template is not handled by any previous template handlers,
+# this function will be called with *parts* as argument.
+last_template_handler = _populate("last_template_handler")

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -1,8 +1,8 @@
 """Catalan language."""
-from typing import Tuple
+import re
+from typing import Pattern, Tuple
 
-# Regex to find the pronunciation
-pronunciation = r"{\s*ca-pron\s*\|(?:q=\S*\|)?(?:\s*or\s*=\s*)?/([^/\|]+)"
+from ...stubs import Pronunciations
 
 # Regex to find the gender
 gender = r"{ca-\w+\|([fm]+)"
@@ -116,8 +116,14 @@ templates_multi = {
     "etim-s": "'segle ' + parts[2]",
 }
 
-# Templates that will be completed/replaced using custom style.
-# templates_other = {}
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(
+        r"{\s*ca-pron\s*\|(?:q=\S*\|)?(?:\s*or\s*=\s*)?(/[^/]+/)"
+    ),
+) -> Pronunciations:
+    return pattern.findall(code)
 
 
 def last_template_handler(

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -117,6 +117,25 @@ templates_multi = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/ca
+release_description = """\
+Les paraules compten: {words_count}
+Abocador Viccionari: {dump_date}
+
+Fitxers disponibles:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Actualitzat el {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Viccionari (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(
@@ -279,22 +298,3 @@ def last_template_handler(
         return f"{trans} {superscript(f'({src})')}"
 
     return defaults.last_template_handler(template, locale, word=word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/ca
-release_description = """\
-Les paraules compten: {words_count}
-Abocador Viccionari: {dump_date}
-
-Fitxers disponibles:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Actualitzat el {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Viccionari (ɔ) {year}"

--- a/wikidict/lang/de/__init__.py
+++ b/wikidict/lang/de/__init__.py
@@ -118,13 +118,30 @@ templates_markierung = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/de
+release_description = """\
+Anzahl Worte: {words_count}
+Wiktionary-Dump vom: {dump_date}
+
+Verfügbare Wörterbuch-Formate:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Letzte Aktualisierung: {creation_date}.</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Wiktionary (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{Lautschrift\|([^}]+)}"),
 ) -> Pronunciations:
-    if matches := pattern.findall(code):
-        return [f"[{p}]" for p in matches]
-    return []
+    return [f"[{p}]" for p in matches] if (matches := pattern.findall(code)) else []
 
 
 def last_template_handler(
@@ -170,22 +187,3 @@ def last_template_handler(
         return template[1]
 
     return default(template, locale, word=word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/de
-release_description = """\
-Anzahl Worte: {words_count}
-Wiktionary-Dump vom: {dump_date}
-
-Verfügbare Wörterbuch-Formate:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Letzte Aktualisierung: {creation_date}.</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Wiktionary (ɔ) {year}"

--- a/wikidict/lang/de/__init__.py
+++ b/wikidict/lang/de/__init__.py
@@ -1,8 +1,8 @@
 """German language (Deutsch)."""
-from typing import Tuple
+import re
+from typing import Pattern, Tuple
 
-# Regex to find the pronunciation
-pronunciation = r"{{Lautschrift\|([^}]+)}}"
+from ...stubs import Pronunciations
 
 # Regex to find the gender
 gender = r",\s+{{([fmnu]+)}}"
@@ -18,6 +18,7 @@ head_sections = ("{{Sprache|Deutsch}}", "{{sprache|deutsch}}")
 etyl_section = ("{{Herkunft}}",)
 sections = (
     *etyl_section,
+    "{{Aussprache}",
     "{{Bedeutungen}",
     "{{Grundformverweis ",
     "{{Alte Schreibweise|",
@@ -115,6 +116,15 @@ templates_markierung = {
     "vul.": "vulgär",
     "vulg.": "vulgär",
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{Lautschrift\|([^}]+)}"),
+) -> Pronunciations:
+    if matches := pattern.findall(code):
+        return [f"[{p}]" for p in matches]
+    return []
 
 
 def last_template_handler(

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -1,9 +1,9 @@
 """Defaults values for locales without specific needs."""
+import re  # noqa
 from collections import defaultdict  # noqa
-from typing import Dict, List, Tuple
+from typing import Dict, List, Pattern, Tuple
 
-# Regex to find the pronunciation
-pronunciation = r""
+from ..stubs import Pronunciations
 
 # Regex to find the gender
 gender = r""
@@ -39,6 +39,14 @@ templates_multi: Dict[str, str] = {}
 
 # Templates that will be completed/replaced using custom style.
 templates_other: Dict[str, str] = {}
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r""),
+) -> Pronunciations:
+    """Function used to find pronunciationswitinh `code`."""
+    return []
 
 
 def last_template_handler(

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -1,5 +1,5 @@
 """Defaults values for locales without specific needs."""
-import re  # noqa
+import re
 from collections import defaultdict  # noqa
 from typing import Dict, List, Pattern, Tuple
 
@@ -45,7 +45,7 @@ def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r""),
 ) -> Pronunciations:
-    """Function used to find pronunciationswitinh `code`."""
+    """Function used to find pronunciations within `code`."""
     return []
 
 

--- a/wikidict/lang/el/__init__.py
+++ b/wikidict/lang/el/__init__.py
@@ -83,6 +83,25 @@ templates_multi: Dict[str, str] = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/el
+release_description = """\
+Αριθμός λέξεων: {words_count}
+Εξαγωγή Βικιλεξικού: {dump_date}
+
+Διαθέσιμα αρχεία:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Ημερομηνία δημιουργίας: {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Βικιλεξικό (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{ΔΦΑ(?:\|γλ=el)?\|([^}\|]+)"),
@@ -127,22 +146,3 @@ def last_template_handler(
         return phrase
 
     return default(template, locale, word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/el
-release_description = """\
-Αριθμός λέξεων: {words_count}
-Εξαγωγή Βικιλεξικού: {dump_date}
-
-Διαθέσιμα αρχεία:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Ημερομηνία δημιουργίας: {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Βικιλεξικό (ɔ) {year}"

--- a/wikidict/lang/el/__init__.py
+++ b/wikidict/lang/el/__init__.py
@@ -1,10 +1,9 @@
 """Greek language."""
-from typing import Dict, Tuple
+import re
+from typing import Dict, Pattern, Tuple
 
-# Regex to find the pronunciation
-# {{ΔΦΑ|tɾeˈlos|γλ=el}}
-# {{ΔΦΑ|γλ=el|ˈni.xta}}
-pronunciation = r"{ΔΦΑ(?:\|γλ=el)?\|([^}\|]+)"
+from ...stubs import Pronunciations
+
 # Regex to find the gender
 # '''{{PAGENAME}}''' {{θ}}
 # '''{{PAGENAME}}''' {{ο}}
@@ -82,6 +81,15 @@ templates_multi: Dict[str, str] = {
     # {{resize|Βικιλεξικό|140}}
     "resize": "f'<span style=\"font-size:{parts[2]}%;\">{parts[1]}</span>'",
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{ΔΦΑ(?:\|γλ=el)?\|([^}\|]+)"),
+) -> Pronunciations:
+    # {{ΔΦΑ|tɾeˈlos|γλ=el}}
+    # {{ΔΦΑ|γλ=el|ˈni.xta}}
+    return pattern.findall(code)
 
 
 def last_template_handler(

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -150,6 +150,25 @@ templates_multi = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/en
+release_description = """\
+Words count: {words_count}
+Wiktionary dump: {dump_date}
+
+Available files:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Updated on {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Wiktionary (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{IPA\|en\|(/[^/]+/)(?:\|(/[^/]+/))*"),
@@ -283,22 +302,3 @@ def last_template_handler(
         return f"{italic(capitalize(tpl))} {strong(parts[1])}"
     except IndexError:
         return capitalize(tpl)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/en
-release_description = """\
-Words count: {words_count}
-Wiktionary dump: {dump_date}
-
-Available files:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Updated on {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Wiktionary (ɔ) {year}"

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -1,10 +1,9 @@
 """English language."""
-from typing import Tuple
+import re
+from typing import List, Pattern, Tuple
 
+from ...stubs import Pronunciations
 from .labels import labels, labels_regional, labels_subvarieties, labels_topical
-
-# Regex to find the pronunciation
-pronunciation = r"{IPA\|en\|/([^/]+)/(?:\|.([^/]+))*"
 
 # Float number separator
 float_separator = "."
@@ -149,6 +148,20 @@ templates_multi = {
     # {{taxlink|Gadus macrocephalus|species|ver=170710}}
     "taxlink": "italic(parts[1])",
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{IPA\|en\|(/[^/]+/)(?:\|(/[^/]+/))*"),
+) -> Pronunciations:
+    matches: List[str] = []
+    for match in pattern.findall(code):
+        # `match` can contain tuples, flatten it
+        if isinstance(match, tuple):
+            matches.extend(res for res in match if res and res not in matches)
+        elif match and match not in matches:
+            matches.append(match)
+    return matches
 
 
 def last_template_handler(

--- a/wikidict/lang/es/__init__.py
+++ b/wikidict/lang/es/__init__.py
@@ -150,13 +150,30 @@ templates_multi = {
 lowercase_italic = ("Rural", "Jergal", "Lunfardismo")
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/es
+release_description = """\
+Número de palabras: {words_count}
+exportación Wikcionario: {dump_date}
+
+Archivos disponibles:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Actualizado el {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Wikcionario (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"fone=([^}\|\s]+)"),
 ) -> Pronunciations:
-    if matches := pattern.findall(code):
-        return [f"[{p}]" for p in matches]
-    return []
+    return [f"[{p}]" for p in match] if (match := pattern.findall(code)) else []
 
 
 def last_template_handler(
@@ -278,22 +295,3 @@ def last_template_handler(
         return parts[0]
 
     return default(template, locale, word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/es
-release_description = """\
-Número de palabras: {words_count}
-exportación Wikcionario: {dump_date}
-
-Archivos disponibles:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Actualizado el {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Wikcionario (ɔ) {year}"

--- a/wikidict/lang/es/__init__.py
+++ b/wikidict/lang/es/__init__.py
@@ -1,10 +1,9 @@
 """Spanish language."""
-from typing import List, Tuple
+import re
+from typing import List, Pattern, Tuple
 
+from ...stubs import Pronunciations
 from .campos_semanticos import campos_semanticos
-
-# Regex to find the pronunciation
-pronunciation = r"fone=([^}\|\s]+)"
 
 # Float number separator
 float_separator = ","
@@ -149,6 +148,15 @@ templates_multi = {
 }
 
 lowercase_italic = ("Rural", "Jergal", "Lunfardismo")
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"fone=([^}\|\s]+)"),
+) -> Pronunciations:
+    if matches := pattern.findall(code):
+        return [f"[{p}]" for p in matches]
+    return []
 
 
 def last_template_handler(

--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -1,12 +1,11 @@
 """French language."""
-from typing import Tuple
+import re
+from typing import Pattern, Tuple
 
+from ...stubs import Pronunciations
 from .arabiser import arabiser
 from .domain_templates import domain_templates
 from .regions import regions
-
-# Regex pour trouver la prononciation
-pronunciation = r"{pron(?:\|lang=fr)?\|([^}\|]+)"
 
 # Regexp pour trouver le gender
 gender = r"{([fmsingp]+)(?: \?\|fr)*}"
@@ -701,6 +700,21 @@ templates_other = {
     "usage": "<b>Note d’usage&nbsp;:</b>",
     "vlatypas-pivot": "v’là-t-i’ pas",
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{pron(?:\|lang=fr)?\|([^}\|]+)"),
+) -> Pronunciations:
+    if not (match := pattern.search(code)):
+        return []
+
+    # There is at least one match, we need to get whole line
+    # in order to be able to find multiple pronunciations
+    line = code[match.start() : code.find("\n", match.start())]
+    if matches := pattern.findall(line):
+        return [f"\\{p}\\" for p in matches]
+    return []
 
 
 def last_template_handler(

--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -702,6 +702,25 @@ templates_other = {
 }
 
 
+# Contenu de la release sur GitHub :
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/fr
+release_description = """\
+Nombre de mots : {words_count}
+Export Wiktionnaire : {dump_date}
+
+Fichiers disponibles :
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Mis à jour le {creation_date}</sub>
+"""  # noqa
+
+# Le nom du dictionnaire qui sera affiché en-dessous de chaque définition
+wiktionary = "Wiktionnaire (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{pron(?:\|lang=fr)?\|([^}\|]+)"),
@@ -928,22 +947,3 @@ def last_template_handler(
 
     # This is a country in the current locale
     return langs[tpl] if tpl in langs else default(template, locale, word=word)
-
-
-# Contenu de la release sur GitHub :
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/fr
-release_description = """\
-Nombre de mots : {words_count}
-Export Wiktionnaire : {dump_date}
-
-Fichiers disponibles :
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Mis à jour le {creation_date}</sub>
-"""  # noqa
-
-# Le nom du dictionnaire qui sera affiché en-dessous de chaque définition
-wiktionary = "Wiktionnaire (ɔ) {year}"

--- a/wikidict/lang/it/__init__.py
+++ b/wikidict/lang/it/__init__.py
@@ -1,8 +1,8 @@
 """Italian language."""
-from typing import Dict, Tuple
+import re
+from typing import Dict, Pattern, Tuple
 
-# Regex to find the pronunciation
-pronunciation = r"{IPA\|/([^/]+)/"
+from ...stubs import Pronunciations
 
 # Regex to find the gender
 gender = r"{{Pn\|?w?}} ''([fm])[singvol ]*''"
@@ -99,3 +99,10 @@ File disponibili:
 
 # Dictionary name that will be printed below each definition
 wiktionary = "Wikizionario (ɔ) {year}"
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{IPA\|(/[^/]+/)"),
+) -> Pronunciations:
+    return pattern.findall(code)

--- a/wikidict/lang/no/__init__.py
+++ b/wikidict/lang/no/__init__.py
@@ -1,8 +1,5 @@
 """Norwegian language."""
 
-# Regex to find the pronunciation
-pronunciation = r""
-
 # Float number separator
 float_separator = ","
 

--- a/wikidict/lang/no/__init__.py
+++ b/wikidict/lang/no/__init__.py
@@ -15,14 +15,6 @@ sections = (
     "Substantiv",
 )
 
-# Templates to ignore: the text will be deleted.
-templates_ignored = ("",)
-
-# Templates more complex to manage.
-templates_multi = {
-    "": "",
-}
-
 # Release content on GitHub
 # https://github.com/BoboTiG/ebook-reader-dict/releases/tag/no
 release_description = """\

--- a/wikidict/lang/pt/__init__.py
+++ b/wikidict/lang/pt/__init__.py
@@ -1,10 +1,9 @@
 """Portuguese language."""
-from typing import Tuple
+import re
+from typing import Pattern, Tuple
 
+from ...stubs import Pronunciations
 from .escopos import escopos
-
-# Regex to find the pronunciation
-pronunciation = r"{AFI\|\[([^\]]+)\]}"
 
 # Regex to find the gender
 gender = r"{([fm]+)}"
@@ -105,6 +104,13 @@ templates_multi = {
     # {{varort|tenu-|pt}}
     "varort": 'f"variante ortográfica de {strong(parts[1])}"',
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{AFI\|(/[^/]+/)"),
+) -> Pronunciations:
+    return pattern.findall(code)
 
 
 def last_template_handler(

--- a/wikidict/lang/pt/__init__.py
+++ b/wikidict/lang/pt/__init__.py
@@ -106,6 +106,25 @@ templates_multi = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/pt
+release_description = """\
+As palavras contam: {words_count}
+Exportação Wikcionário: {dump_date}
+
+Arquivos disponíveis:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Actualizado em {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Wikcionário (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{AFI\|(/[^/]+/)"),
@@ -322,22 +341,3 @@ def last_template_handler(
         return langs[tpl].capitalize()
 
     return default(template, locale, word=word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/pt
-release_description = """\
-As palavras contam: {words_count}
-Exportação Wikcionário: {dump_date}
-
-Arquivos disponíveis:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Actualizado em {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Wikcionário (ɔ) {year}"

--- a/wikidict/lang/ru/__init__.py
+++ b/wikidict/lang/ru/__init__.py
@@ -10,6 +10,7 @@ gender = r"(?:{сущ.ru.)([fmnмжс])|(?:{сущ.ru.*\|)([fmnмжс])"
 
 # Float number separator
 float_separator = ","
+
 # Thousads separator
 thousands_separator = " "
 
@@ -31,6 +32,25 @@ sections = (
 
 # Some definitions are not good to keep (plural, gender, ... )
 templates_ignored = ("семантика",)
+
+
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/ru
+release_description = """\
+Количество слов : {words_count}
+Экспорт Викисловаря : {dump_date}
+
+Доступные файлы :
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Обновлено по {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Викисловарь (ɔ) {year}"
 
 
 def find_pronunciations(
@@ -55,22 +75,3 @@ def last_template_handler(
 
     # This is a country in the current locale
     return langs[tpl] if tpl in langs else default(template, locale, word=word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/ru
-release_description = """\
-Количество слов : {words_count}
-Экспорт Викисловаря : {dump_date}
-
-Доступные файлы :
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Обновлено по {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Викисловарь (ɔ) {year}"

--- a/wikidict/lang/ru/__init__.py
+++ b/wikidict/lang/ru/__init__.py
@@ -1,9 +1,8 @@
 """Russian language."""
-from typing import Tuple
+import re
+from typing import Pattern, Tuple
 
-# Regex to find the pronunciation
-# TODO need to expand template for russian Произношение (rn just get stem)
-pronunciation = r"(?:transcriptions-ru.)(\w*)"
+from ...stubs import Pronunciations
 
 # Regex to find the gender
 # https://ru.wiktionary.org/wiki/%D0%A8%D0%B0%D0%B1%D0%BB%D0%BE%D0%BD:%D1%81%D1%83%D1%89-ru
@@ -32,6 +31,13 @@ sections = (
 
 # Some definitions are not good to keep (plural, gender, ... )
 templates_ignored = ("семантика",)
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"(?:transcriptions-ru.)(\w*)"),
+) -> Pronunciations:
+    return list(set(pattern.findall(code)))
 
 
 def last_template_handler(

--- a/wikidict/lang/sv/__init__.py
+++ b/wikidict/lang/sv/__init__.py
@@ -89,13 +89,30 @@ _gammalstavning = {
 }
 
 
+# Release content on GitHub
+# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/sv
+release_description = """\
+Ord räknas: {words_count}
+Dumpa Wiktionary: {dump_date}
+
+Tillgängliga filer:
+
+- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
+- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
+- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
+
+<sub>Uppdaterad på {creation_date}</sub>
+"""  # noqa
+
+# Dictionary name that will be printed below each definition
+wiktionary = "Wiktionary (ɔ) {year}"
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{uttal\|sv\|(?:[^\|]+\|)?ipa=([^}]+)}"),
 ) -> Pronunciations:
-    if match := pattern.findall(code):
-        return [f"/{p}/" for p in match]
-    return []
+    return [f"/{p}/" for p in match] if (match := pattern.findall(code)) else []
 
 
 def last_template_handler(
@@ -163,22 +180,3 @@ def last_template_handler(
         return f"{italic(cat)} {parts[-1]}"
 
     return default(template, locale, word=word)
-
-
-# Release content on GitHub
-# https://github.com/BoboTiG/ebook-reader-dict/releases/tag/sv
-release_description = """\
-Ord räknas: {words_count}
-Dumpa Wiktionary: {dump_date}
-
-Tillgängliga filer:
-
-- [Kobo]({url_kobo}) (dicthtml-{locale}-{locale}.zip)
-- [StarDict]({url_stardict}) (dict-{locale}-{locale}.zip)
-- [DictFile]({url_dictfile}) (dict-{locale}-{locale}.df.bz2)
-
-<sub>Uppdaterad på {creation_date}</sub>
-"""  # noqa
-
-# Dictionary name that will be printed below each definition
-wiktionary = "Wiktionary (ɔ) {year}"

--- a/wikidict/lang/sv/__init__.py
+++ b/wikidict/lang/sv/__init__.py
@@ -1,9 +1,8 @@
 """Swedish language."""
 import re
-from typing import Tuple
+from typing import Pattern, Tuple
 
-# Regex to find the pronunciation
-pronunciation = r"{uttal\|sv\|(?:[^\|]+\|)?ipa=([^}]+)}"
+from ...stubs import Pronunciations
 
 # Float number separator
 float_separator = ","
@@ -88,6 +87,15 @@ _gammalstavning = {
     "auh": "genom rättskrivningsreformen 1996 ",
     "zs": "genom stavningsreformen 1973 ",
 }
+
+
+def find_pronunciations(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{uttal\|sv\|(?:[^\|]+\|)?ipa=([^}]+)}"),
+) -> Pronunciations:
+    if match := pattern.findall(code):
+        return [f"/{p}/" for p in match]
+    return []
 
 
 def last_template_handler(

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -15,9 +15,9 @@ import wikitextparser._spans
 from .lang import (
     definitions_to_ignore,
     etyl_section,
+    find_pronunciations,
     gender,
     head_sections,
-    pronunciation,
     section_level,
     section_patterns,
     section_sublevels,
@@ -220,7 +220,7 @@ def find_etymology(
     return definitions
 
 
-def find_gender(code: str, pattern: Pattern[str]) -> str:
+def _find_gender(code: str, pattern: Pattern[str]) -> str:
     """Find the gender."""
     match = pattern.search(code)
     if not match:
@@ -229,7 +229,7 @@ def find_gender(code: str, pattern: Pattern[str]) -> str:
     return groups[0] or "" if groups else ""
 
 
-def find_pronunciations(
+def _find_pronunciations(
     top_sections: List[wtp.Section], func: Callable[[str], Pronunciations]
 ) -> List[str]:
     """Find pronunciations."""
@@ -350,8 +350,8 @@ def parse_word(word: str, code: str, locale: str, force: bool = False) -> Word:
     definitions = find_definitions(word, parsed_sections, locale)
 
     if definitions or force:
-        prons = find_pronunciations(top_sections, pronunciation[locale])
-        nature = find_gender(code, gender[locale])
+        prons = _find_pronunciations(top_sections, find_pronunciations[locale])
+        nature = _find_gender(code, gender[locale])
 
     for title, parsed_section in parsed_sections.items():
         # Find potential variants

--- a/wikidict/stubs.py
+++ b/wikidict/stubs.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple, Union
 SubDefinitions = Union[str, Tuple[str, ...]]
 Definitions = Union[str, Tuple[str, ...], Tuple[SubDefinitions, ...]]
 Parts = Tuple[str, ...]
+Pronunciations = List[str]
 Variants = Dict[str, List[str]]
 Word = namedtuple("Word", "pronunciations, gender, etymology, definitions, variants")
 Words = Dict[str, Word]

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -64,7 +64,7 @@ def convert_gender(gender: str) -> str:
 
 def convert_pronunciation(pronunciations: List[str]) -> str:
     """Return the HTML code to include for the etymology of a word."""
-    return " " + ", ".join(f"\\{p}\\" for p in pronunciations) if pronunciations else ""
+    return f" {', '.join(pronunciations)}" if pronunciations else ""
 
 
 def get_word_of_the_day(locale: str) -> str:


### PR DESCRIPTION
Fixes #1174.

I reviewed completely how pronunciations were retrieved in order to tackle that task, including changing where pronunciations were looked for: before we were using the whole word wikicode, now we only use `head_sections` wikicode (faster, and more efficient).

It has the following nice side-effects (on top the having local-specific formatting like `\...\` for French, `[...]` for German, etc.):
- `EN`, `FR`: now supports multiple cross-sections pronunciations (like ones from Middle English combined to ones from Old English sections, for instance on English data)
- `FR`: pronunciations outside the French section are no more taken into account (like using values from Gaulois or other locale sections, that was incorrect)
- `PT`: a lot more pronunciations are correctly found now
- `SV`: multiple pronunciations are now supported
- `RU`: it will be way easier to tackle #1376 then