### PR TITLE
Genders refactoring

### DIFF
--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -1,38 +1,23 @@
 import pytest
 
-from wikidict.lang.ca import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{ca-pron|/as/}}", ["/as/"]),
-        ("{{ca-pron|or=/əɫ/}}", ["/əɫ/"]),
-        ("{{ca-pron|or=/əɫ/|occ=/eɫ/}}", ["/əɫ/"]),
-        ("{{ca-pron|q=àton|or=/əɫ/|occ=/eɫ/|rima=}}", ["/əɫ/"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions",
+    "word, pronunciations, genders, etymology, definitions",
     [
         (
             "-ass-",
             ["/as/"],
-            "",
+            [],
             ["Del sufix <i>-às</i> amb valor augmentatiu."],
             ["Infix que afegeix un matís augmentatiu."],
         ),
         (
             "-itzar",
             [],
-            "",
+            [],
             ["Del llatí <i>-izare</i>, del grec antic <i>-ίζειν</i>."],
             [
                 "<i>Aplicat a un substantiu o adjectiu forma un verb que expressa la seva realització o convertir-se'n.</i>",  # noqa
@@ -41,25 +26,25 @@ def test_find_pronunciations(code, expected):
         (
             "AFI",
             ["/ˈa.fi/"],
-            "",
+            [],
             ["sigles"],
             [
                 "(<i>m</i>) Alfabet Fonètic Internacional.",
                 "(<i>f</i>) Associació Fonètica Internacional.",
             ],
         ),
-        ("avui", [], "", [], ["En el dia actual.", "Metafòricament, en el present."]),
+        ("avui", [], [], [], ["En el dia actual.", "Metafòricament, en el present."]),
         (
             "bio-",
             [],
-            "",
+            [],
             [],
             ['Element que entra en la composició de paraules amb el sentit de "vida".'],
         ),
         (
             "bot",
             [],
-            "m",
+            ["m"],
             [""],
             [
                 "Recipient de cuir, originalment de boc per a contenir vi.",
@@ -77,7 +62,7 @@ def test_find_pronunciations(code, expected):
         (
             "cap",
             [],
-            "m",
+            ["m", "mf"],
             [
                 "Del llatí vulgar <i>*capu(m)</i>, variant de l’acusatiu <i>caput</i>, segle XIII. Com a adjectiu pel sentit d’«extrem, punta». Com a preposició pel sentit de «part anterior (vers un lloc)»."  # noqa
             ],
@@ -111,7 +96,7 @@ def test_find_pronunciations(code, expected):
         (
             "cas",
             ["/ˈkas/"],
-            "m",
+            ["m"],
             ["Del llatí <i>casus</i>."],
             [
                 "Situació particular que es produeix entre les diverses possibles.",
@@ -124,7 +109,7 @@ def test_find_pronunciations(code, expected):
         (
             "Castell",
             [],
-            "",
+            [],
             ["De <i>castell</i>."],
             [
                 "Diversos topònims, especialment:",
@@ -144,7 +129,7 @@ def test_find_pronunciations(code, expected):
         (
             "català",
             [],
-            "m",
+            ["m"],
             [
                 "D’origen incert, paral·lel al de <i>Catalunya</i>, possiblement metàtesi del llatí <i>lacetani</i> («lacetans»)."  # noqa
             ],
@@ -162,7 +147,7 @@ def test_find_pronunciations(code, expected):
         (
             "ch",
             [],
-            "",
+            [],
             [],
             [
                 "Codi de llengua ISO 639-1 del chamorro.",
@@ -172,7 +157,7 @@ def test_find_pronunciations(code, expected):
         (
             "compte",
             [],
-            "m",
+            ["m"],
             ["Del llatí <i>compŭtus</i>, segle XIII."],
             [
                 "Acte de comptar.",
@@ -185,7 +170,7 @@ def test_find_pronunciations(code, expected):
         (
             "disset",
             [],
-            "m",
+            ["m", "f"],
             ["Del llatí <i>decem</i> <i>et</i> <i>septem</i> («deu i set»)."],
             [
                 "<i>(cardinal)</i> Nombre enter situat entre el setze i el divuit.",
@@ -197,7 +182,7 @@ def test_find_pronunciations(code, expected):
         (
             "el",
             ["/əɫ/"],
-            "f",
+            ["f"],
             [],
             [
                 "Codi de llengua ISO 639-1 del grec modern.",
@@ -210,17 +195,17 @@ def test_find_pronunciations(code, expected):
         (
             "hivernacle",
             [],
-            "m",
+            ["m"],
             ["Del llatí <i>hibernaculum</i>."],
             ["Cobert per a protegir plantes del vent o del fred extrem."],
         ),
-        ("Mn.", [], "", [], ["mossèn com a tractament davant el nom"]),
-        ("PMF", ["/ˌpeˈe.məˌe.fə/"], "", [], ["Preguntes Més Freqüents."]),
-        ("pen", [], "", [], []),
+        ("Mn.", [], [], [], ["mossèn com a tractament davant el nom"]),
+        ("PMF", ["/ˌpeˈe.məˌe.fə/"], [], [], ["Preguntes Més Freqüents."]),
+        ("pen", [], [], [], []),
         (
             "si",
             [],
-            "m",
+            ["m"],
             [],
             [
                 "Codi de llengua ISO 639-1 del singalès.",
@@ -232,12 +217,12 @@ def test_find_pronunciations(code, expected):
         ),
     ],
 )
-def test_parse_word(word, pronunciations, gender, etymology, definitions, page):
+def test_parse_word(word, pronunciations, genders, etymology, definitions, page):
     """Test the sections finder and definitions getter."""
     code = page(word, "ca")
     details = parse_word(word, code, "ca", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert definitions == details.definitions
     assert etymology == details.etymology
 

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,35 +1,16 @@
 import pytest
 
-from wikidict.lang.de import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        (
-            ":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}",
-            ["[ˈʁɪndɐˌsteːk]"],
-        ),
-        (
-            ":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}, {{Lautschrift|ˈʁɪndɐˌʃteːk}}, {{Lautschrift|ˈʁɪndɐˌsteɪ̯k}}",
-            ["[ˈʁɪndɐˌsteːk]", "[ˈʁɪndɐˌʃteːk]", "[ˈʁɪndɐˌsteɪ̯k]"],
-        ),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions, variants",
+    "word, pronunciations, genders, etymology, definitions, variants",
     [
         (
             "CIA",
             ["[siːaɪ̯ˈɛɪ̯]"],
-            "mf",
+            ["mf"],
             ["Abkürzung von Central Intelligence Agency"],
             ["US-amerikanischer Auslandsnachrichtendienst"],
             [],
@@ -37,7 +18,7 @@ def test_find_pronunciations(code, expected):
         (
             "volley",
             ["[ˈvɔli]", "[ˈvɔle]", "[ˈvɔlɛɪ̯]"],
-            "",
+            [],
             [
                 "Dem seit 1960 im Duden lexikalisierten Wort liegt die englische Kollokation <i>at/on the <i>volley</i></i> ‚aus der Luft‘ zugrunde.",  # noqa
             ],
@@ -46,18 +27,18 @@ def test_find_pronunciations(code, expected):
             ],
             [],
         ),
-        ("trage", ["[ˈtʁaːɡə]"], "", [], [], ["tragen"]),
-        ("daß", [], "", [], [], ["dass"]),
+        ("trage", ["[ˈtʁaːɡə]"], [], [], [], ["tragen"]),
+        ("daß", [], [], [], [], ["dass"]),
     ],
 )
 def test_parse_word(
-    word, pronunciations, gender, etymology, definitions, variants, page
+    word, pronunciations, genders, etymology, definitions, variants, page
 ):
     """Test the sections finder and definitions getter."""
     code = page(word, "de")
     details = parse_word(word, code, "de", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert etymology == details.etymology
     assert definitions == details.definitions
     assert variants == details.variants

--- a/tests/test_el.py
+++ b/tests/test_el.py
@@ -1,29 +1,16 @@
 import pytest
 
-from wikidict.lang.el import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{ΔΦΑ|tɾeˈlos|γλ=el}}", ["tɾeˈlos"]),
-        ("{{ΔΦΑ|γλ=el|ˈni.xta}}", ["ˈni.xta"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions, variants",
+    "word, pronunciations, genders, etymology, definitions, variants",
     [
         (
             "λαμβάνω",
             ["el"],
-            "",
+            [],
             ["<b>λαμβάνω</b> < < <i>(Ετυμ)</i> *<i>sleh₂gʷ</i>-"],
             [
                 "παίρνω, δέχομαι",
@@ -35,13 +22,13 @@ def test_find_pronunciations(code, expected):
     ],
 )
 def test_parse_word(
-    word, pronunciations, gender, etymology, definitions, variants, page
+    word, pronunciations, genders, etymology, definitions, variants, page
 ):
     """Test the sections finder and definitions getter."""
     code = page(word, "el")
     details = parse_word(word, code, "el", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert definitions == details.definitions
     assert etymology == details.etymology
     assert variants == details.variants

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -1,23 +1,7 @@
 import pytest
 
-from wikidict.lang.en import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
-
-
-@pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{IPA|en|/ʌs/}}", ["/ʌs/"]),
-        ("{{IPA|en|/ʌs/|/ʌs/}}", ["/ʌs/"]),
-        ("{{IPA|en|/ʌs/}} {{IPA|en|/ʌs/}}", ["/ʌs/"]),
-        ("{{IPA|en|/ʌs/}}, {{IPA|en|/ʌz/}}", ["/ʌs/", "/ʌz/"]),
-        ("{{IPA|en|/ʌs/|/ʌz/}}", ["/ʌs/", "/ʌz/"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -1,28 +1,7 @@
 import pytest
 
-from wikidict.lang.es import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
-
-
-@pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{pron-graf|fone=ˈa.t͡ʃo}}", ["[ˈa.t͡ʃo]"]),
-        (
-            "{{pron-graf|pron=seseo|altpron=No seseante|fone=ˈgɾa.θjas|2pron=seseo|alt2pron=Seseante|2fone=ˈgɾa.sjas|audio=Gracias (español).ogg}}",  # noqa
-            ["[ˈgɾa.θjas]", "[ˈgɾa.sjas]"],
-        ),
-        ("{{pronunciación|[ ˈrwe.ɰo ]}} ", ["[ˈrwe.ɰo]"]),
-        (
-            "{{pronunciación|[ los ] o [ lɔʰ ]<ref>[http://congresosdelalengua.es/valladolid/ponencias/unidad_diversidad_del_espanol/2_el_espanol_de_america/saez_l.htm http://congresosdelalengua.es/valladolid/ponencias/unidad_diversidad_del_espanol/2_el_espanol_de_america/saez_l.htm] Consultado el 11 de noviembre de 2012</ref>}}",  # noqa
-            ["[los]", "[lɔʰ]"],
-        ),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fr.py
+++ b/tests/test_fr.py
@@ -1,29 +1,16 @@
 import pytest
 
-from wikidict.lang.fr import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{pron|ɑ|fr}}", ["\\ɑ\\"]),
-        ("{{pron|ɑ|fr}}, {{pron|a|fr}}", ["\\ɑ\\", "\\a\\"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions, variants",
+    "word, pronunciations, genders, etymology, definitions, variants",
     [
         (
             "-eresse",
             ["\\(ə).ʁɛs\\"],
-            "f",
+            ["f"],
             [
                 "<i>(Date à préciser)</i> Ce suffixe est né d’une coupe erronée du suffixe des mots comme <i>enchanteresse</i> et <i>pécheresse</i>. En effet, ces derniers sont en fait le cas sujet de mots en <i>-eur</i> auquel on a ajouté le suffixe féminisant <i>-esse</i> sous le schéma suivant :",  # noqa
                 '<table style="border: 1px solid black; border-collapse: collapse;"><tr><th style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">cas sujet</th><th style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">cas régime</th><th style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">cas sujet + <i>-esse</i></th></tr><tr><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">pechere</td><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">pecheur</td><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">pecheresse</td></tr><tr><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">enchantere</td><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">enchanteur</td><td style="border: 1px solid black; padding: 0.2em 0.4em; font-size: 2.5em;">enchanteresse</td></tr></table>',  # noqa
@@ -38,7 +25,7 @@ def test_find_pronunciations(code, expected):
         (
             "a",
             ["\\ɑ\\", "\\a\\"],
-            "m",
+            ["m"],
             [],
             [
                 "<i>(Linguistique)</i> Symbole de l’alphabet phonétique international pour la voyelle (ou vocoïde) ouverte antérieure non arrondie.",  # noqa
@@ -55,7 +42,7 @@ def test_find_pronunciations(code, expected):
         (
             "π",
             [],
-            "",
+            [],
             [],
             [
                 "<i>(Mathématiques)</i> Symbole représentant le rapport constant entre la circonférence d’un cercle et son diamètre, aussi appelé en français la <i>constante d’Archimède</i>.",  # noqa
@@ -66,7 +53,7 @@ def test_find_pronunciations(code, expected):
         (
             "42",
             ["\\ka.ʁɑ̃t.dø\\"],
-            "msing",
+            ["msing"],
             [],
             [
                 "Numéral en chiffres arabes du nombre quarante-deux, en notation décimale. Selon la base utilisée, ce numéral peut représenter d’autres nombres. En notation hexadécimale, par exemple, ce numéral représente le nombre soixante-six ; en octal, le nombre trente-quatre.",  # noqa
@@ -81,7 +68,7 @@ def test_find_pronunciations(code, expected):
         (
             "accueil",
             ["\\a.kœj\\"],
-            "m",
+            ["m"],
             ["<u><i>(XII<sup>e</sup> siècle)</i> Déverbal de <i>accueillir</i>.</u>"],
             [
                 "Cérémonie ou prestation réservée à un nouvel arrivant, consistant généralement à lui souhaiter la bienvenue et à l’aider dans son intégration ou ses démarches.",  # noqa
@@ -95,7 +82,7 @@ def test_find_pronunciations(code, expected):
         (
             "acrologie",
             ["\\a.kʁɔ.lɔ.ʒi\\"],
-            "f",
+            ["f"],
             [
                 "Du grec ancien ἄκρος, <i>akros</i> («&nbsp;extrémité&nbsp;»), voir <i>acro-</i>, avec le suffixe <i>-logie</i>."  # noqa
             ],
@@ -110,7 +97,7 @@ def test_find_pronunciations(code, expected):
         (
             "aux",
             ["\\o\\"],
-            "mf",
+            ["mf", "p"],
             [],
             [
                 "<i>(Linguistique)</i> Code ISO 639-3 de l’aurá.",
@@ -121,7 +108,7 @@ def test_find_pronunciations(code, expected):
         (
             "base",
             ["\\bɑz\\"],
-            "f",
+            ["f"],
             [
                 "<i>(Date à préciser)</i> Du latin <i>basis</i> («&nbsp;id.&nbsp;»), du grec ancien βάσις, <i>básis</i> («&nbsp;marche&nbsp;»)."  # noqa
             ],
@@ -159,7 +146,7 @@ def test_find_pronunciations(code, expected):
         (
             "bath",
             ["\\bat\\"],
-            "m",
+            ["m"],
             [
                 "(<i>Adjectif, nom 1</i>) <i>(1846)</i> Origine discutée :",
                 (
@@ -180,7 +167,7 @@ def test_find_pronunciations(code, expected):
         (
             "Bogotanais",
             ["\\bɔ.ɡɔ.ta.nɛ\\"],
-            "m",
+            ["m", "sp"],
             ["Du nom Bogota avec le préfixe -ais."],
             [],
             [],
@@ -188,7 +175,7 @@ def test_find_pronunciations(code, expected):
         (
             "colligeait",
             ["\\kɔ.li.ʒɛ\\"],
-            "",
+            [],
             [],
             [],
             ["colliger"],
@@ -196,7 +183,7 @@ def test_find_pronunciations(code, expected):
         (
             "corps portant",
             ["\\kɔʁ pɔʁ.tɑ̃\\"],
-            "m",
+            ["m"],
             ["Locution composée de <i>corps</i> et de <i>portant</i>."],
             [
                 "<i>(Astronautique)</i> Aéronef à fuselage porteur, sur lequel la portance est produite par le fuselage, destiné aux usages spatiaux ou hypersoniques, afin de limiter l'effet de traînée ou la surface de friction.",  # noqa
@@ -207,7 +194,7 @@ def test_find_pronunciations(code, expected):
         (
             "DES",
             [],
-            "m",
+            ["m"],
             [
                 "<i>(Commerce international)</i> <i>(1936)</i> Terme créé par la Chambre de commerce internationale. Sigle de l’anglais <i>delivered ex ship</i>; « rendu par navire »."  # noqa
             ],
@@ -226,7 +213,7 @@ def test_find_pronunciations(code, expected):
         (
             "dubitatif",
             ["\\dy.bi.ta.tif\\"],
-            "",
+            [],
             ["Du latin <i>dubitativus</i>."],
             [
                 "Qui sert à exprimer le doute.",
@@ -237,7 +224,7 @@ def test_find_pronunciations(code, expected):
         (
             "effluve",
             ["\\e.flyv\\"],
-            "mf",
+            ["mf"],
             [
                 "Du latin <i>effluvium</i>, du préfixe <i>ex-</i> indiquant la séparation et de <i>fluxus</i> (« écoulement »)."  # noqa
             ],
@@ -250,7 +237,7 @@ def test_find_pronunciations(code, expected):
         (
             "employer",
             ["\\ɑ̃.plwa.je\\"],
-            "",
+            [],
             ["Du latin <i>implicāre</i> («&nbsp;impliquer&nbsp;»)."],
             [
                 "Utiliser ; user ; se servir de.",
@@ -262,7 +249,7 @@ def test_find_pronunciations(code, expected):
         (
             "encyclopædie",
             ["\\ɑ̃.si.klɔ.pe.di\\"],
-            "f",
+            ["f"],
             ["→ voir <i>encyclopédie</i>"],
             ["<i>(Archaïsme)</i> <i>Variante orthographique de</i> encyclopédie."],
             [],
@@ -270,7 +257,7 @@ def test_find_pronunciations(code, expected):
         (
             "éperon",
             ["\\e.pʁɔ̃\\"],
-            "m",
+            ["m"],
             ["De l’ancien français <i>esperon</i>, du vieux-francique *<i>sporo</i>."],
             [
                 "<i>(Équitation)</i> Pièce de métal à deux branches, qui s’adapte au talon du cavalier et dont l’extrémité pointue ou portant une molette sert à piquer les flancs du cheval pour le stimuler.",  # noqa
@@ -290,7 +277,7 @@ def test_find_pronunciations(code, expected):
         (
             "greffier",
             ["\\ɡʁɛ.fje\\", "\\ɡʁe.fje\\"],
-            "m",
+            ["m"],
             [
                 "(<i>Nom commun 1</i>) <i>(Date à préciser)</i> Du latin <i>graphiarius</i> («&nbsp;d’écriture, de style, de poinçon&nbsp;») ou dérivé de <i>greffe</i>, avec le suffixe <i>-ier</i>.",  # noqa
                 "(<i>Nom commun 2</i>) <i>(Date à préciser)</i> Sans doute par jeu de mot avec <i>griffes</i> → voir <i>chat-fourré</i>.",  # noqa
@@ -307,7 +294,7 @@ def test_find_pronunciations(code, expected):
         (
             "ich",
             [],
-            "",
+            [],
             [],
             ["<i>(Linguistique)</i> Code ISO 639-3 de l’etkywan."],
             [],
@@ -315,7 +302,7 @@ def test_find_pronunciations(code, expected):
         (
             "koro",
             ["\\kɔ.ʁo\\"],
-            "m",
+            ["m"],
             [],
             [
                 "Langue tibéto-birmane parlée dans l’Arunachal Pradesh (Inde)",
@@ -327,7 +314,7 @@ def test_find_pronunciations(code, expected):
         (
             "mutiner",
             ["\\my.ti.ne\\"],
-            "",
+            [],
             ["Dénominal de <i>mutin</i>."],
             [
                 "Se porter à la sédition, à la révolte.",
@@ -339,7 +326,7 @@ def test_find_pronunciations(code, expected):
         (
             "naguère",
             ["\\na.ɡɛʁ\\"],
-            "",
+            [],
             ["De <i>il n’y a guère</i> (de temps). Voir aussi <i>na</i>."],
             [
                 "Récemment ; il y a peu.",
@@ -352,7 +339,7 @@ def test_find_pronunciations(code, expected):
         # (
         #     "pinyin",
         #     ["\\pin.jin\\"],
-        #     "m",
+        #     ["m"],
         #     "<i>(Nom 1)</i> (Vers 1950) Du chinois 拼音, <i>pīnyīn</i>, formé de 拼 <i>pīn</i> (« épeler ») et de 音 <i>yīn</i> (« son »), donc «\xa0épeler les sons\xa0».",  # noqa
         #     [
         #         "Système de transcription de la langue chinoise, permettant de romaniser les sons des sinogrammes, et d’indiquer le ton utilisé lors de la prononciation.",  # noqa
@@ -363,7 +350,7 @@ def test_find_pronunciations(code, expected):
         (
             "précepte",
             ["\\pʁe.sɛpt\\"],
-            "m",
+            ["m"],
             [
                 "Emprunté au latin <i>praeceptum</i> («&nbsp;précepte, leçon, règle&nbsp;»), dérivé de <i>praecipere</i> signifiant « prendre avant, prendre le premier » ou encore « recommander », « conseiller », « prescrire »."  # noqa
             ],
@@ -378,7 +365,7 @@ def test_find_pronunciations(code, expected):
         (
             "rance",
             ["\\ʁɑ̃s\\"],
-            "mf",
+            ["mf", "m"],
             ["Du latin <i>rancidus</i> par l’intermédiaire de l’ancien occitan."],
             [
                 "Se dit des corps gras qui, laissés au contact de l’air, ont pris une odeur forte et un goût désagréable.",  # noqa
@@ -391,7 +378,7 @@ def test_find_pronunciations(code, expected):
         (
             "sapristi",
             ["\\sa.pʁis.ti\\"],
-            "",
+            [],
             ["Déformation de <i>sacristi</i>, afin de ne pas blasphémer ouvertement."],
             ["Pour marquer l’étonnement."],
             [],
@@ -399,7 +386,7 @@ def test_find_pronunciations(code, expected):
         (
             "silicone",
             ["\\si.li.kon\\"],
-            "f",
+            ["f", "m"],
             [
                 "<i>(1863)</i> De l’allemand <i>Silikon</i>, mot créé par Friedrich Wöhler et, pour les équivalents français du mot allemand, dérivé de <i>silicium</i>, avec le suffixe <i>-one</i>."  # noqa
             ],
@@ -415,7 +402,7 @@ def test_find_pronunciations(code, expected):
         (
             "suis",
             ["\\sɥi\\"],
-            "",
+            [],
             [
                 "<i>(Forme de verbe 1)</i> De l’ancien français <i>suis</i> (forme du verbe <i>estre</i>), lui-même issu du latin <i>sum</i> (forme du verbe <i>esse</i>)."  # noqa
             ],
@@ -425,7 +412,7 @@ def test_find_pronunciations(code, expected):
         (
             "Turgeon",
             ["\\tyʁ.ʒɔ̃\\"],
-            "",
+            [],
             [
                 "Nom en rapport avec l’esturgeon «&nbsp;Turgeon&nbsp;» dans Jean <span style='font-variant:small-caps'>Tosti</span>, <i>Les noms de famille</i>."  # noqa
             ],
@@ -435,13 +422,13 @@ def test_find_pronunciations(code, expected):
     ],
 )
 def test_parse_word(
-    word, pronunciations, gender, etymology, definitions, variants, page
+    word, pronunciations, genders, etymology, definitions, variants, page
 ):
     """Test the sections finder and definitions getter."""
     code = page(word, "fr")
     details = parse_word(word, code, "fr", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert definitions == details.definitions
     assert etymology == details.etymology
     assert variants == details.variants

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,28 +1,16 @@
 import pytest
 
-from wikidict.lang.it import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{IPA|/kondiˈvidere/}}", ["/kondiˈvidere/"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions",
+    "word, pronunciations, genders, etymology, definitions",
     [
         (
             "condividere",
             ["/kondiˈvidere/"],
-            "",
+            [],
             [
                 "dal latino <i>cum</i> e <i>dividere</i>; l'attuale uso improprio del verbo <i>condividere</i> è dovuto alla diffusione dei social network negli anni 2000 e 2010",  # noqa
             ],
@@ -37,7 +25,7 @@ def test_find_pronunciations(code, expected):
         (
             "debolmente",
             ["/debolˈmente/"],
-            "",
+            [],
             ["composto dall'aggettivo debole e dal suffisso -mente"],
             [
                 "in maniera debole, con debolezza",
@@ -46,7 +34,7 @@ def test_find_pronunciations(code, expected):
         (
             "lettore",
             ["/letˈtore/"],
-            "m",
+            ["m"],
             ['dal latino <i>lector</i>, derivazione di <i>legĕre</i> ossia "leggere"'],
             [
                 "chi legge un libro, un giornale o una rivista",
@@ -56,12 +44,12 @@ def test_find_pronunciations(code, expected):
         ),
     ],
 )
-def test_parse_word(word, pronunciations, gender, etymology, definitions, page):
+def test_parse_word(word, pronunciations, genders, etymology, definitions, page):
     """Test the sections finder and definitions getter."""
     code = page(word, "it")
     details = parse_word(word, code, "it", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert etymology == details.etymology
     assert definitions == details.definitions
 

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -1,44 +1,31 @@
 import pytest
 
-from wikidict.lang.pt import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
+    "word, pronunciations, genders, etymology, definitions",
     [
-        ("", []),
-        ("{{AFI|/pɾe.ˈno.me̝/}}", ["/pɾe.ˈno.me̝/"]),
-        ("{{AFI|/pɾe.ˈno.me̝/|lang=pt}}", ["/pɾe.ˈno.me̝/"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions",
-    [
-        ("ababalhar", [], "", ["De baba."], ["<i>(popular)</i> babar; conspurcar"]),
+        ("ababalhar", [], [], ["De baba."], ["<i>(popular)</i> babar; conspurcar"]),
         (
             "alguém",
             ["/aɫ.ˈɡɐ̃j̃/"],
-            "",
+            [],
             ["Do latim <i>alĭquem</i> <sup>(la)</sup>."],
             ["pessoa não identificada"],
         ),
         (
             "algo",
             ["/ˈaɫ.ɡu/"],
-            "",
+            [],
             [],
             ["um pouco, de certo modo", "objeto (não-identificado) de que se fala"],
         ),
         (
             "baiano",
             [],
-            "",
+            [],
             ["Derivado de Bahia, mais o sufixo ano, com perda do H."],
             [
                 "do Estado da Bahia, Brasil",
@@ -49,7 +36,7 @@ def test_find_pronunciations(code, expected):
         (
             "cabrum",
             [],
-            "mf",
+            ["mf"],
             ['Do latim <i>caprunu</i> <sup>(la)</sup> "cabra".'],
             [
                 "<i>(Pecuária)</i> de cabras:",
@@ -60,7 +47,7 @@ def test_find_pronunciations(code, expected):
         (
             "COPOM",
             ["/ko.ˈpõ/"],
-            "m",
+            ["m"],
             [],
             [
                 "<b>C</b>entro de <b>O</b>perações da <b>Po</b>lícia <b>M</b>ilitar",
@@ -70,7 +57,7 @@ def test_find_pronunciations(code, expected):
         (
             "dezassete",
             ["/dɨ.zɐ.ˈsɛ.tɨ/"],
-            "",
+            [],
             ["Contração do latim vulgar <i>decem</i> + <i>ac</i> + <i>septem</i>."],
             [
                 "o número dezassete (17, XVII)",
@@ -82,7 +69,7 @@ def test_find_pronunciations(code, expected):
         (
             "etc",
             [],
-            "",
+            [],
             [],
             [
                 'abreviação do latim <i>et cetera</i>, que significa "e outros", "e os restantes" e "e outras coisas mais"',  # noqa
@@ -91,7 +78,7 @@ def test_find_pronunciations(code, expected):
         (
             "-ista",
             [],
-            "",
+            [],
             [
                 "Do grego antigo <i>-ιστεσ</i> (<i>-istes</i>) através do latim <i>-ista</i> através do francês antigo <i>-iste</i>."  # noqa
             ],
@@ -105,7 +92,7 @@ def test_find_pronunciations(code, expected):
         (
             "neo-",
             [],
-            "",
+            [],
             ["Do grego antigo <i>νέος</i>."],
             [
                 "exprime a ideia de <i>novo</i>",
@@ -115,14 +102,14 @@ def test_find_pronunciations(code, expected):
         (
             "para",
             ["/ˈpɐ.ɾɐ/"],
-            "",
+            [],
             [],
             ["exprime fim, destino, lugar, tempo, direção etc"],
         ),
         (
             "paulista",
             [],
-            "",
+            [],
             [],
             [
                 "diz-se de pessoa de origem do Estado de São Paulo, Brasil",
@@ -131,11 +118,11 @@ def test_find_pronunciations(code, expected):
                 "artigo ou objeto do Estado de São Paulo",
             ],
         ),
-        ("tenui-", [], "", [], ["variante ortográfica de <b>tenu-</b>"]),
+        ("tenui-", [], [], [], ["variante ortográfica de <b>tenu-</b>"]),
         (
             "to",
             [],
-            "",
+            [],
             [],
             [
                 "<i>(antigo)</i> contração do pronome pessoal te com o pronome pessoal ou demonstrativo o",
@@ -145,21 +132,21 @@ def test_find_pronunciations(code, expected):
         (
             "ũa",
             [],
-            "",
+            [],
             [
                 "Do Latim <i>una-</i>: <i>una-</i> deu <b>ũa</b> por queda do <b>n</b> com a nasalação do <b>ũ</b>."
             ],
             ["ortografia antiga de uma"],
         ),
-        ("UTC", [], "", [], ["<i>(estrangeirismo)</i> ver TUC"]),
+        ("UTC", [], [], [], ["<i>(estrangeirismo)</i> ver TUC"]),
     ],
 )
-def test_parse_word(word, pronunciations, gender, etymology, definitions, page):
+def test_parse_word(word, pronunciations, genders, etymology, definitions, page):
     """Test the sections finder and definitions getter."""
     code = page(word, "pt")
     details = parse_word(word, code, "pt", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert etymology == details.etymology
     assert definitions == details.definitions
 

--- a/tests/test_ru.py
+++ b/tests/test_ru.py
@@ -1,37 +1,18 @@
 import pytest
 
-from wikidict.lang.ru import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        # Execpeted behaviour after #1376
-        # (
-        #     "{{transcriptions-ru|страни́ца|страни́цы|Ru-страница.ogg}}",
-        #     ["[strɐˈnʲit͡sə]"],
-        # ),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
-
-
-@pytest.mark.parametrize(
-    "word, pronunciations, gender, etymology, definitions, variants",
+    "word, pronunciations, genders, etymology, definitions, variants",
     [
         (
             "страница",
             ["страни"],
-            "f",
+            ["f"],
             [
-                "Происходит от страна, из церк.-слав. страна, далее из праслав.\xa0*storna, от кот. в числе прочего \
-произошли: др.-русск. сторона, ст.-слав. страна (др.-греч. χώρα, περίχωρος), русск., укр. сторона́, болг. \
-страна́, сербохорв. стра́на (вин. стра̑ну), словенск. strána, чешск., словацк. strana, польск. strona, \
-в.-луж., н.-луж. strona, полабск. stárna"
+                "Происходит от страна, из церк.-слав. страна, далее из праслав.\xa0*storna, от кот. в числе прочего произошли: др.-русск. сторона, ст.-слав. страна (др.-греч. χώρα, περίχωρος), русск., укр. сторона́, болг. страна́, сербохорв. стра́на (вин. стра̑ну), словенск. strána, чешск., словацк. strana, польск. strona, в.-луж., н.-луж. strona, полабск. stárna",  # noqa
             ],
             [
                 "одна из сторон листа бумаги в составе книги, газеты и\xa0т.\xa0п.",
@@ -39,15 +20,14 @@ def test_find_pronunciations(code, expected):
                 "лист бумаги в составе книги, газеты и\xa0т.\xa0п.",
                 "<i>(Комп.)</i> отдельный документ в составе интернет-сайта",
                 "<i>(П.)</i> очередной этап в развитии чего-либо",
-                "<i>(Информ.)</i> блок, регион фиксированного размера физической или виртуальной памяти (выделение \
-памяти, передача данных между диском и оперативной памятью осуществляется целыми страницами)",
+                "<i>(Информ.)</i> блок, регион фиксированного размера физической или виртуальной памяти (выделение памяти, передача данных между диском и оперативной памятью осуществляется целыми страницами)",  # noqa
             ],
             [],
         ),
         (
             "какой",
             [],
-            "",
+            [],
             ["Происходит от ?"],
             [
                 "(вопросительное мест.) обозначает вопрос о качестве, свойствах",
@@ -65,12 +45,9 @@ def test_find_pronunciations(code, expected):
         (
             "коса",
             ["коса"],
-            "",
+            ["с", "m"],
             [
-                "Родств. церковносл./укр./болг./серб. коса, польск./словац./др.-чеш. kosa. М. Фасмер неубедительно \
-связывает с др.-исл. haddr (волосы, протогерм. *hazda-), ср.-ирл. cír (гребень), лит. kasa, kasyti, kasît, др.-инд. \
-<i>kacchus</i>, авест. <i>kasvis</i>, а тж. чередованием гласных с чесать, чешу и косма. Э. Бернекер, М. Рясянен и \
-др. сводят коса I, коса II и коса III к косой."
+                "Родств. церковносл./укр./болг./серб. коса, польск./словац./др.-чеш. kosa. М. Фасмер неубедительно связывает с др.-исл. haddr (волосы, протогерм. *hazda-), ср.-ирл. cír (гребень), лит. kasa, kasyti, kasît, др.-инд. <i>kacchus</i>, авест. <i>kasvis</i>, а тж. чередованием гласных с чесать, чешу и косма. Э. Бернекер, М. Рясянен и др. сводят коса I, коса II и коса III к косой.",  # noqa
             ],
             [
                 "вид укладки волос, при которой волосы собираются в несколько прядей и затем переплетаются",
@@ -87,7 +64,7 @@ def test_find_pronunciations(code, expected):
         (
             "бита",
             [],
-            "f",
+            ["f", "ж"],
             ["Происходит от ?"],
             [
                 "предмет (палка, бабка и\xa0т.\xa0п.), которым бьют во время игры в городки, в бабки, в лапту и\xa0т.\xa0п.",  # noqa
@@ -98,13 +75,13 @@ def test_find_pronunciations(code, expected):
     ],
 )
 def test_parse_word(
-    word, pronunciations, gender, etymology, definitions, variants, page
+    word, pronunciations, genders, etymology, definitions, variants, page
 ):
     """Test the sections finder and definitions getter."""
     code = page(word, "ru")
     details = parse_word(word, code, "ru", force=True)
     assert pronunciations == details.pronunciations
-    assert gender == details.gender
+    assert genders == details.genders
     assert definitions == details.definitions
     assert etymology == details.etymology
     assert variants == details.variants

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -1,19 +1,7 @@
 import pytest
 
-from wikidict.lang.sv import find_pronunciations
 from wikidict.render import parse_word
 from wikidict.utils import process_templates
-
-
-@pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("", []),
-        ("{{uttal|sv|ipa=eːn/, /ɛn/, /en}}", ["/eːn/, /ɛn/, /en/"]),
-    ],
-)
-def test_find_pronunciations(code, expected):
-    assert find_pronunciations(code) == expected
 
 
 @pytest.mark.parametrize(

--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -266,7 +266,7 @@ class KoboFormat(KoboBaseFormat):
                     definitions = self.create_definitions(details)
 
                     pronunciation = convert_pronunciation(details.pronunciations)
-                    gender = convert_gender(details.gender)
+                    gender = convert_gender(details.genders)
                     etymology = self.create_etymology(details.etymology)
 
                     var = ""
@@ -315,7 +315,7 @@ class DictFileFormat(KoboBaseFormat):
                 definitions = self.create_definitions(details)
 
                 pronunciation = convert_pronunciation(details.pronunciations)
-                gender = convert_gender(details.gender)
+                gender = convert_gender(details.genders)
                 etymology = self.create_etymology(details.etymology)
                 fh.write(f"@ {word}\n")
                 if pronunciation or gender:

--- a/wikidict/get_word.py
+++ b/wikidict/get_word.py
@@ -39,7 +39,7 @@ def get_and_parse_word(word: str, locale: str, raw: bool = False) -> None:
     print(
         word,
         convert_pronunciation(details.pronunciations).lstrip(),
-        strip_html(convert_gender(details.gender).lstrip()),
+        strip_html(convert_gender(details.genders).lstrip()),
         "\n",
     )
 

--- a/wikidict/lang/__init__.py
+++ b/wikidict/lang/__init__.py
@@ -1,6 +1,5 @@
 """Internationalization stuff."""
-import re
-from typing import Any, Callable, Dict, Pattern, Tuple, TypeVar
+from typing import Any, Dict, Tuple, TypeVar
 
 from . import ca, de, defaults, el, en, es, fr, it, no, pt, ru, sv
 from .ca.langs import langs as CA
@@ -55,28 +54,18 @@ Arg = TypeVar("Arg")
 PopulatedDict = Dict[str, Any]
 
 
-def _noop_callback(arg: Arg) -> Arg:
-    """Simply returns the argument."""
-    return arg
-
-
-def _populate(
-    attr: str, callback: Callable[[Any], Any] = _noop_callback
-) -> PopulatedDict:
+def _populate(attr: str) -> PopulatedDict:
     """
     Create a dict for all locales pointing to the appropriate attribute.
     Fallback to `defaults`.
     """
     return {
-        locale.__name__.split(".")[-1]: callback(getattr(locale, attr))
+        locale.__name__.split(".")[-1]: getattr(locale, attr)
         if hasattr(locale, attr)
-        else callback(getattr(defaults, attr))
+        else getattr(defaults, attr)
         for locale in _ALL_LOCALES
     }
 
-
-# Regex to find the gender
-gender: Dict[str, Pattern[str]] = _populate("gender", callback=re.compile)
 
 # Float number separator
 float_separator: Dict[str, str] = _populate("float_separator")
@@ -139,7 +128,10 @@ release_description: Dict[str, str] = _populate("release_description")
 # Dictionary name that will be printed below each definition
 wiktionary: Dict[str, str] = _populate("wiktionary")
 
-# Function to find the pronunciation
+# Function to find gender(s)
+find_genders = _populate("find_genders")
+
+# Function to find pronunciation(s)
 find_pronunciations = _populate("find_pronunciations")
 
 # When a template is not handled by any previous template handlers,

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -1,11 +1,6 @@
 """Catalan language."""
 import re
-from typing import Pattern, Tuple
-
-from ...stubs import Pronunciations
-
-# Regex to find the gender
-gender = r"{ca-\w+\|([fm]+)"
+from typing import List, Pattern, Tuple
 
 # Float number separator
 float_separator = ","
@@ -136,12 +131,43 @@ Fitxers disponibles:
 wiktionary = "Viccionari (ɔ) {year}"
 
 
+def find_genders(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{ca-\w+\|([fm]+)"),
+) -> List[str]:
+    """
+    >>> find_genders("")
+    []
+    >>> find_genders("{{ca-nom|m}}")
+    ['m']
+    >>> find_genders("{{ca-nom|m}} {{ca-nom|m}}")
+    ['m']
+    """
+    matches: List[str] = []
+    for match in pattern.findall(code):
+        if match not in matches:
+            matches.append(match)
+    return matches
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(
         r"{\s*ca-pron\s*\|(?:q=\S*\|)?(?:\s*or\s*=\s*)?(/[^/]+/)"
     ),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{ca-pron|/as/}}")
+    ['/as/']
+    >>> find_pronunciations("{{ca-pron|or=/əɫ/}}")
+    ['/əɫ/']
+    >>> find_pronunciations("{{ca-pron|or=/əɫ/|occ=/eɫ/}}")
+    ['/əɫ/']
+    >>> find_pronunciations("{{ca-pron|q=àton|or=/əɫ/|occ=/eɫ/|rima=}}")
+    ['/əɫ/']
+    """
     return pattern.findall(code)
 
 

--- a/wikidict/lang/de/__init__.py
+++ b/wikidict/lang/de/__init__.py
@@ -1,11 +1,6 @@
 """German language (Deutsch)."""
 import re
-from typing import Pattern, Tuple
-
-from ...stubs import Pronunciations
-
-# Regex to find the gender
-gender = r",\s+{{([fmnu]+)}}"
+from typing import List, Pattern, Tuple
 
 # Float number separator
 float_separator = ","
@@ -35,9 +30,6 @@ templates_ignored = (
     "QS Herkunft",
     "QS_Herkunft",
 )
-
-# Templates that will be completed/replaced using italic style.
-# templates_italic = {}
 
 # Templates more complex to manage.
 templates_multi = {
@@ -137,10 +129,31 @@ Verfügbare Wörterbuch-Formate:
 wiktionary = "Wiktionary (ɔ) {year}"
 
 
+def find_genders(
+    code: str,
+    pattern: Pattern[str] = re.compile(r",\s+{{([fmnu]+)}}"),
+) -> List[str]:
+    """
+    >>> find_genders("")
+    []
+    >>> find_genders("=== {{Wortart|Abkürzung|Deutsch}}, {{mf}}, {{Wortart|Substantiv|Deutsch}} ===")
+    ['mf']
+    """
+    return pattern.findall(code)
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{Lautschrift\|([^}]+)}"),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations(":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}")
+    ['[ˈʁɪndɐˌsteːk]']
+    >>> find_pronunciations(":{{IPA}} {{Lautschrift|ˈʁɪndɐˌsteːk}}, {{Lautschrift|ˈʁɪndɐˌʃteːk}}, {{Lautschrift|ˈʁɪndɐˌsteɪ̯k}}")
+    ['[ˈʁɪndɐˌsteːk]', '[ˈʁɪndɐˌʃteːk]', '[ˈʁɪndɐˌsteɪ̯k]']
+    """  # noqa
     return [f"[{p}]" for p in matches] if (matches := pattern.findall(code)) else []
 
 

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -3,11 +3,6 @@ import re
 from collections import defaultdict  # noqa
 from typing import Dict, List, Pattern, Tuple
 
-from ..stubs import Pronunciations
-
-# Regex to find the gender
-gender = r""
-
 # Float number separator
 float_separator = ""
 
@@ -41,10 +36,18 @@ templates_multi: Dict[str, str] = {}
 templates_other: Dict[str, str] = {}
 
 
+def find_genders(
+    code: str,
+    pattern: Pattern[str] = re.compile(r""),
+) -> List[str]:
+    """Function used to find genders within `code`."""
+    return []
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r""),
-) -> Pronunciations:
+) -> List[str]:
     """Function used to find pronunciations within `code`."""
     return []
 

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -2,7 +2,6 @@
 import re
 from typing import List, Pattern, Tuple
 
-from ...stubs import Pronunciations
 from .labels import labels, labels_regional, labels_subvarieties, labels_topical
 
 # Float number separator
@@ -172,7 +171,21 @@ wiktionary = "Wiktionary (ɔ) {year}"
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{IPA\|en\|(/[^/]+/)(?:\|(/[^/]+/))*"),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{IPA|en|/ʌs/}}")
+    ['/ʌs/']
+    >>> find_pronunciations("{{IPA|en|/ʌs/|/ʌs/}}")
+    ['/ʌs/']
+    >>> find_pronunciations("{{IPA|en|/ʌs/}} {{IPA|en|/ʌs/}}")
+    ['/ʌs/']
+    >>> find_pronunciations("{{IPA|en|/ʌs/}}, {{IPA|en|/ʌz/}}")
+    ['/ʌs/', '/ʌz/']
+    >>> find_pronunciations("{{IPA|en|/ʌs/|/ʌz/}}")
+    ['/ʌs/', '/ʌz/']
+    """
     matches: List[str] = []
     for match in pattern.findall(code):
         # `match` can contain tuples, flatten it

--- a/wikidict/lang/es/__init__.py
+++ b/wikidict/lang/es/__init__.py
@@ -2,7 +2,6 @@
 import re
 from typing import List, Pattern, Tuple
 
-from ...stubs import Pronunciations
 from .campos_semanticos import campos_semanticos
 
 # Float number separator
@@ -176,7 +175,19 @@ def find_pronunciations(
     pattern2: Pattern[str] = re.compile(
         r"{pronunciación\|\[\s*([^}\|\s]+)\s*\](?:.*\[\s*([^}\|\s]+)\s*\])*"
     ),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{pron-graf|fone=ˈa.t͡ʃo}}")
+    ['[ˈa.t͡ʃo]']
+    >>> find_pronunciations("{{pron-graf|pron=seseo|altpron=No seseante|fone=ˈgɾa.θjas|2pron=seseo|alt2pron=Seseante|2fone=ˈgɾa.sjas|audio=Gracias (español).ogg}}")
+    ['[ˈgɾa.θjas]', '[ˈgɾa.sjas]']
+    >>> find_pronunciations("{{pronunciación|[ ˈrwe.ɰo ]}}")
+    ['[ˈrwe.ɰo]']
+    >>> find_pronunciations("{{pronunciación|[ los ] o [ lɔʰ ]<ref>[l.htm l.htm] C</ref>}}")
+    ['[los]', '[lɔʰ]']
+    """  # noqa
     pattern = pattern2 if "{pronunciación|" in code else pattern1
     matches: List[str] = []
     for match in pattern.findall(code):

--- a/wikidict/lang/it/__init__.py
+++ b/wikidict/lang/it/__init__.py
@@ -1,11 +1,6 @@
 """Italian language."""
 import re
-from typing import Dict, Pattern, Tuple
-
-from ...stubs import Pronunciations
-
-# Regex to find the gender
-gender = r"{{Pn\|?w?}} ''([fm])[singvol ]*''"
+from typing import Dict, List, Pattern, Tuple
 
 # Float number separator
 float_separator = ","
@@ -101,8 +96,27 @@ File disponibili:
 wiktionary = "Wikizionario (ɔ) {year}"
 
 
+def find_genders(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{{Pn\|?w?}} ''([fm])[singvol ]*''"),
+) -> List[str]:
+    """
+    >>> find_genders("")
+    []
+    >>> find_genders("{{Pn}} ''m sing''")
+    ['m']
+    """
+    return pattern.findall(code)
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{IPA\|(/[^/]+/)"),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{IPA|/kondiˈvidere/}}")
+    ['/kondiˈvidere/']
+    """
     return pattern.findall(code)

--- a/wikidict/lang/pt/__init__.py
+++ b/wikidict/lang/pt/__init__.py
@@ -1,12 +1,8 @@
 """Portuguese language."""
 import re
-from typing import Pattern, Tuple
+from typing import List, Pattern, Tuple
 
-from ...stubs import Pronunciations
 from .escopos import escopos
-
-# Regex to find the gender
-gender = r"{([fm]+)}"
 
 # Float number separator
 float_separator = ","
@@ -125,10 +121,33 @@ Arquivos disponíveis:
 wiktionary = "Wikcionário (ɔ) {year}"
 
 
+def find_genders(
+    code: str,
+    pattern: Pattern[str] = re.compile(r"{([fm]+)}"),
+) -> List[str]:
+    """
+    >>> find_genders("")
+    []
+    >>> find_genders("{{oxítona|ca|brum}}, {{mf}}")
+    ['mf']
+    >>> find_genders("'''COPOM''', {{m}}")
+    ['m']
+    """
+    return pattern.findall(code)
+
+
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{AFI\|(/[^/]+/)"),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{AFI|/pɾe.ˈno.me̝/}}")
+    ['/pɾe.ˈno.me̝/']
+    >>> find_pronunciations("{{AFI|/pɾe.ˈno.me̝/|lang=pt}}")
+    ['/pɾe.ˈno.me̝/']
+    """
     return pattern.findall(code)
 
 

--- a/wikidict/lang/sv/__init__.py
+++ b/wikidict/lang/sv/__init__.py
@@ -1,8 +1,6 @@
 """Swedish language."""
 import re
-from typing import Pattern, Tuple
-
-from ...stubs import Pronunciations
+from typing import List, Pattern, Tuple
 
 # Float number separator
 float_separator = ","
@@ -111,7 +109,13 @@ wiktionary = "Wiktionary (ɔ) {year}"
 def find_pronunciations(
     code: str,
     pattern: Pattern[str] = re.compile(r"{uttal\|sv\|(?:[^\|]+\|)?ipa=([^}]+)}"),
-) -> Pronunciations:
+) -> List[str]:
+    """
+    >>> find_pronunciations("")
+    []
+    >>> find_pronunciations("{{uttal|sv|ipa=eːn/, /ɛn/, /en}}")
+    ['/eːn/, /ɛn/, /en/']
+    """
     return [f"/{p}/" for p in match] if (match := pattern.findall(code)) else []
 
 

--- a/wikidict/stubs.py
+++ b/wikidict/stubs.py
@@ -5,8 +5,7 @@ from typing import Dict, List, Tuple, Union
 SubDefinitions = Union[str, Tuple[str, ...]]
 Definitions = Union[str, Tuple[str, ...], Tuple[SubDefinitions, ...]]
 Parts = Tuple[str, ...]
-Pronunciations = List[str]
 Variants = Dict[str, List[str]]
-Word = namedtuple("Word", "pronunciations, gender, etymology, definitions, variants")
+Word = namedtuple("Word", "pronunciations, genders, etymology, definitions, variants")
 Words = Dict[str, Word]
 Groups = Dict[str, Words]

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -57,13 +57,16 @@ SPECIAL_TEMPLATES = {
 }
 
 
-def convert_gender(gender: str) -> str:
-    """Return the HTML code to include for the gender of a word."""
-    return f" <i>{gender}.</i>" if gender else ""
+def convert_gender(genders: List[str]) -> str:
+    """Return the HTML code to include for gender(s) of a word."""
+    if not genders:
+        return ""
+    genders = [f"<i>{gender}.</i>" for gender in genders]
+    return f" {', '.join(genders)}"
 
 
 def convert_pronunciation(pronunciations: List[str]) -> str:
-    """Return the HTML code to include for the etymology of a word."""
+    """Return the HTML code to include for pronunciation(s) of a word."""
     return f" {', '.join(pronunciations)}" if pronunciations else ""
 
 


### PR DESCRIPTION
Same work as done for pronunciations in #1377.

- fixes #993 
- multiple genders support for all locales
- moved pronunciations, and genders, tests into doctests

Maybe the new code, and the one for pronunciations, could be refactored more to automatically get rid of duplicates (and still keeping the retrieval order).