### PR TITLE
Arabic and Persian scripts not rendered in italic

### DIFF
--- a/tests/test_es.py
+++ b/tests/test_es.py
@@ -132,7 +132,7 @@ from wikidict.utils import process_templates
             "hasta",
             ["[ˈas.ta]"],
             [
-                'Del castellano antiguo <i>fasta</i>, del más antiguo <i>hata</i>, <i>fata</i>, quizá préstamo del árabe <i>حتى</i> (<i>ḥatta</i>), o del latín <i>ad</i> ("a") <i>ista</i> ("esta"), o de ambos.'  # noqa
+                'Del castellano antiguo <i>fasta</i>, del más antiguo <i>hata</i>, <i>fata</i>, quizá préstamo del árabe حتى (<i>ḥatta</i>), o del latín <i>ad</i> ("a") <i>ista</i> ("esta"), o de ambos.'  # noqa
             ],
             [
                 "Preposición que indica el fin o término de una actividad, sea en sentido locativo, cronológico o cuantitativo.",  # noqa

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -434,6 +434,11 @@ def process_templates(word: str, text: str, locale: str) -> str:
         >>> process_templates("test", r"<hiero>R11</hiero>", "fr")
         '<table class="mw-hiero-table mw-hiero-outer" dir="ltr" style=" border: 0; border-spacing: 0; font-size:1em;"><tr><td style="padding: 0; text-align: center; vertical-align: middle; font-size:1em;">\n<table class="mw-hiero-table" style="border: 0; border-spacing: 0; font-size:1em;"><tr>\n<td style="padding: 0; text-align: center; vertical-align: middle; font-size:1em;"><img src="data:image/gif;base64...'
 
+        >>> process_templates("hasta", "<i>حتى</i>", "es")
+        'حتى'
+        >>> process_templates("tasse", "<i>س tas'</i>", "fr")
+        "س tas'"
+
     """  # noqa
 
     sub = re.sub
@@ -462,6 +467,9 @@ def process_templates(word: str, text: str, locale: str) -> str:
     text = sub(r"<math>([^<]+)</math>", partial(convert_math, word=word), text)
     text = sub(r"<chem>([^<]+)</chem>", partial(convert_chem, word=word), text)
     text = sub(r"<hiero>(.+)</hiero>", partial(convert_hiero, word=word), text)
+
+    # Issue #584: move Arabic/Persian characters out of italic tags
+    text = sub(r"<i>([^<]*[\u0627-\u064a]+[^<]*)</i>", r"\1", text)
 
     # Remove extra spaces (it happens when a template is ignored for instance)
     text = sub(r"\s{2,}", " ", text)


### PR DESCRIPTION
Fixes #584.

It's fixed for all devices, and all locales.
Maybe is it too broad for such a fix? I'm fine with that, as soon as you are too @lasconic.

Bonus point: `--check-word` passes just fine with such changes.