### PR TITLE
Remove default italic

### DIFF
--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -78,10 +78,6 @@ def last_template_handler(
         text = parts[1] if len(parts) == 2 else word
         return transliterate(lang, text)
 
-    # {{tpl|item}} -> <i>(Templatet gf)</i>
-    if len(template) == 2:
-        return term(capitalize(lookup_italic(tpl, locale)))
-
     if italic := lookup_italic(tpl, locale, True):
         return term(capitalize(italic))
 

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -281,6 +281,7 @@ def last_template_handler(
         italic,
         strong,
     )
+    from .. import defaults
     from .form_of import form_of_templates
     from .langs import langs
     from .template_handlers import (
@@ -349,7 +350,4 @@ def last_template_handler(
     if tpl in ("zh-l", "zh-m"):
         return chinese(parts, data)
 
-    try:
-        return f"{italic(capitalize(tpl))} {strong(parts[1])}"
-    except IndexError:
-        return capitalize(tpl)
+    return defaults.last_template_handler(template, locale, word=word)


### PR DESCRIPTION
It will help us catch missing templates without `--check-word`.