### PR TITLE
[IT] Improve Wikicode transformation to properly split foreign locale…

### DIFF
--- a/tests/data/it/nominative.wiki
+++ b/tests/data/it/nominative.wiki
@@ -1,0 +1,25 @@
+{{Trasfen}}
+
+== {{-it-}} ==
+{{-agg form-|it}}
+'''nominative''' ''f pl''
+# Femminile plurale di [[nominativo]].
+
+== {{-en-}} ==
+{{-agg-|en}}
+# {{Term|grammatica|it}} {{Term|linguistica|it}} Giving a name; naming; designating; — said of that [[case]] or form of a [[noun]] which stands as the subject of a [[finite verb]].
+
+{{-etim-}}
+''[[nominativus]]'', pertaining to naming, nominative.
+
+{{-sost-|en}}
+{{Pn}}
+# The [[nominative case]].
+
+== {{-ro-}} ==
+{{-agg-|ro}}
+# [[nominativo]]
+
+{{-sost-|ro}}
+{{Pn}} ''n''
+# [[nominativo]]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -45,6 +45,13 @@ from wikidict.utils import process_templates
                 "<small><i>(elettronica)</i></small> <small><i>(informatica)</i></small> <small><i>(tecnologia)</i></small> <small><i>(ingegneria)</i></small> dispositivo elettronico che decodifica e riceve informazioni da un supporto",  # noqa
             ],
         ),
+        (
+            "nominative",
+            [],
+            [],
+            [],
+            ["Femminile plurale di nominativo."],
+        ),
     ],
 )
 def test_parse_word(

--- a/wikidict/lang/it/__init__.py
+++ b/wikidict/lang/it/__init__.py
@@ -18,6 +18,7 @@ sections = (
     *etyl_section,
     "{{acron}",
     "{{agg}",
+    "{{agg form}",
     "{{avv}",
     "{{art}",
     "{{cong}",

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -336,11 +336,16 @@ def parse_word(word: str, code: str, locale: str, force: bool = False) -> Word:
     elif locale == "it":
         # {{-avv-|it}} -> === {{avv}} ===
         code = re.sub(
-            r"^\{\{-(.+)-\|it?\}\}", r"=== {{\1}} ===", code, flags=re.MULTILINE
+            r"^\{\{-(.+)-\|it\}\}", r"=== {{\1}} ===", code, flags=re.MULTILINE
+        )
+
+        # {{-avv-|ANY}} -> === {{avv|ANY}} ===
+        code = re.sub(
+            r"^\{\{-(.+)-\|(\w+)\}\}", r"=== {{\1|\2}} ===", code, flags=re.MULTILINE
         )
 
         # {{-avv-}} -> === {{avv}} ===
-        code = re.sub(r"^\{\{-(.+)-\}\}", r"=== {{\1}} ===", code, flags=re.MULTILINE)
+        code = re.sub(r"^\{\{-(\w+)-\}\}", r"=== {{\1}} ===", code, flags=re.MULTILINE)
 
     top_sections, parsed_sections = find_sections(code, locale)
     prons = []


### PR DESCRIPTION
… sections

Also take into account `{{agg form}}` sub-section.

Fixes #1672 
