### PR TITLE
fix #1678: Fix template transformation cache issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 setuptools>=36.2.1
 beautifulsoup4==4.11.1
-cachetools==5.3.0
 docopt==0.6.2
 Jinja2==3.1.2
 marisa-trie==0.7.8

--- a/wikidict/utils.py
+++ b/wikidict/utils.py
@@ -7,13 +7,11 @@ from contextlib import suppress
 from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
-from typing import Callable, List, Match, Tuple, Union
+from typing import Callable, List, Match, Union
 
 import regex
 import requests
 import wikitextparser
-from cachetools import cached
-from cachetools.keys import hashkey
 
 from . import svg
 from .constants import (
@@ -671,14 +669,8 @@ def transform(word: str, template: str, locale: str) -> str:
     elif tpl == "PAGENAME" or (tpl == "w" and len(parts) == 1):
         return word.replace("_", " ")
 
-    # Convert *parts* from a list to a tuple because list are not hashable and thus cannot be used
-    # with the LRU cache.
-    return str(transform_apply(word, tpl, tuple(parts), locale))
+    # Apply transformations
 
-
-@cached(cache={}, key=lambda word, tpl, parts, locale: hashkey(tpl, parts, locale))  # type: ignore
-def transform_apply(word: str, tpl: str, parts: Tuple[str, ...], locale: str) -> str:
-    """Convert the data from the *tpl* template of the *word* using the *locale*."""
     with suppress(KeyError):
         return eval(templates_multi[locale][tpl])  # type: ignore
 


### PR DESCRIPTION
Fixes #1678

The improvement is light, but it removes any cache issues.
This also improves a little bit the overall process because we get rid of a list -> tuple conversion, and we removed a function call for each word.

See https://github.com/BoboTiG/ebook-reader-dict/issues/1678#issuecomment-1403361013 for numbers.