### PR TITLE
Switch to pyglossary.glossary_v2

### DIFF
--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -436,7 +436,7 @@ class StarDictFormat(DictFileFormat):
 
     def _convert(self) -> None:
         """Convert the DictFile to StarDict."""
-        from pyglossary import Glossary
+        from pyglossary.glossary_v2 import Glossary, ConvertArgs
 
         Glossary.init()
         glos = Glossary()
@@ -449,12 +449,12 @@ class StarDictFormat(DictFileFormat):
         glos.setInfo(
             "date", f"{self.snapshot[:4]}-{self.snapshot[4:6]}-{self.snapshot[6:8]}"
         )
-        res = glos.convert(
+        res = glos.convert(ConvertArgs(
             inputFilename=str(self.dictionnary_file(DictFileFormat.output_file)),
             outputFilename=str(self.output_dir / "dict-data.ifo"),
             writeOptions={"dictzip": True},
             sqlite=True,
-        )
+        ))
         assert res, "Conversion failed!"
 
     def _cleanup(self) -> None:

--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -449,12 +449,14 @@ class StarDictFormat(DictFileFormat):
         glos.setInfo(
             "date", f"{self.snapshot[:4]}-{self.snapshot[4:6]}-{self.snapshot[6:8]}"
         )
-        res = glos.convert(ConvertArgs(
-            inputFilename=str(self.dictionnary_file(DictFileFormat.output_file)),
-            outputFilename=str(self.output_dir / "dict-data.ifo"),
-            writeOptions={"dictzip": True},
-            sqlite=True,
-        ))
+        res = glos.convert(
+            ConvertArgs(
+                inputFilename=str(self.dictionnary_file(DictFileFormat.output_file)),
+                outputFilename=str(self.output_dir / "dict-data.ifo"),
+                writeOptions={"dictzip": True},
+                sqlite=True,
+            )
+        )
         assert res, "Conversion failed!"
 
     def _cleanup(self) -> None:


### PR DESCRIPTION
`pyglossary.glossary_v2` module is added in [PyGlossary 4.6.0](https://github.com/ilius/pyglossary/releases/tag/4.6.0).

[A quick overview of differences in README](https://github.com/ilius/pyglossary#using-pyglossary-as-a-python-library).

`pyglossary.glossary` (and `from pyglossary import Glossary`) is kept for compatibility (not deprecated).