### PR TITLE
[RO] Fix verb support + handle all templates found

### DIFF
--- a/tests/data/ro/cânta.wiki
+++ b/tests/data/ro/cânta.wiki
@@ -1,0 +1,85 @@
+{{vezi|cântă|canta|cantá|cantà|cantâ|çanta}}
+=={{limba|ron}}==
+{{-etimologie-}}
+Din latină ''[[cantare]]''.
+{{-pronunție-}}
+* {{AFI}}: {{AFI|/kɨnˈta/}}
+{{-verb-|ron}}
+{{verb-ron
+|inf=cânta
+|ind=cânt
+|conj=cânte
+|part=cântat
+|cj=I
+}}
+#(''v.intranz. și tranz.'') a [[emite]] cu [[voce]]a sau cu un [[instrument]] un [[șir]] de [[sunet]]e [[muzical]]e care se [[rândui]]esc într-o [[melodie]], într-un [[acord]] etc.
+#:''A '''cânta''' o melodie, o doină.''
+#:'''''Cântă''' din fluier.''
+#(''despre păsări, insecte etc.'') a [[scoate]] [[sunet]]e [[plăcut]]e la [[auz]]. [[caracteristice]] [[specie]]i.
+#(''v.intranz. și tranz.'') a [[scrie]] [[vers]]uri în [[cinste]]a [[cuiva]] sau a [[ceva]], a [[elogia]] (în versuri) pe [[cineva]] sau [[ceva]]; a [[descrie]], a [[povesti]] ceva în [[vers]]uri.
+#(''v.tranz.'') (''fam.'') a [[îndruga]], a [[înșira]] [[vorbă|vorbe]] [[gol|goale]].
+{{-sin-}}
+*'''1:''' (muz.) [[executa]], [[interpreta]], [[intona]], (pop.) [[glăsui]], [[spune]], [[viersui]], [[zice]], (înv.) [[glăsi]], [[juca]], (muz.) [[suna]]
+{{-ant-}}
+* [[vorbi]]
+{{-deriv-}}
+{{(|cuvinte derivate}}
+* [[cantabil]]
+* [[cantată]]
+* [[canto]]
+* [[cantor]]
+* [[canțonetă]]
+* [[canțonetist]]
+* [[cântare]]
+{{-}}
+* [[cântăreț]], [[cântăreață]]
+* [[cântat]]
+* [[cântător]], [[cântătoare]]
+* [[încânta]]
+* [[încântare]]
+* [[încântător]]
+{{)}}
+{{-expr-}}
+*'''''Joacă cum îi cântă''' = face întocmai cum îi poruncește altul''
+{{-trans-}}
+{{(|a emite sunete cu vocea sau cu un intrument}}
+*{{sqi}}: {{trad|sq|këndon}}
+*{{ara}}: {{trad|ar|غنى|(ğániya)}}
+*{{rup}}: {{trad|rup|cîntu}}
+*{{bul}}: {{trad|bg|пея}}
+*{{cat}}: {{trad|ca|cantar}}
+*{{ces}}: {{trad|cs|zpívat}}
+*{{zho}}: {{trad|zh|唱|(chàng)}}
+*{{kor}}: {{trad|ko|노래하다|(noraehada)}}
+*{{hrv}}: {{trad|hr|pjevati}}
+*{{dan}}: {{trad|da|synge}}
+*{{eng}}: {{trad|en|sing}}
+*{{epo}}: {{trad|eo|kanti}}
+*{{fin}}: {{trad|fi|laulaa}}
+*{{fra}}: {{trad|fr|chanter}}
+*{{glg}}: {{trad|gl|cantar}}
+*{{deu}}: {{trad|de|singen}}
+*{{ell}}: {{trad|el|τραγουδώ|(tragudó)}}
+*{{ind}}: {{trad|id|bernyanyi|(''un om'')}}, {{trad|id|berkicau|(''o pasăre'')}}
+{{-}}
+*{{gle}}: {{trad|ga|can}}
+*{{isl}}: {{trad|is|syngja}}
+*{{ita}}: {{trad|it|cantare}}
+*{{jpn}}: {{trad|ja|歌う|(うたう, utau) (''un om'')}}  , {{trad|ja|鳴く|(なく, naku) (''o pasăre'')}}
+*{{lat}}: {{trad|la|cantare}}
+*{{hun}}: {{trad|hu|énekel}}
+*{{nld}}: {{trad|nl|zingen}}
+*{{oci}}: {{trad|oc|cantar}}
+*{{pol}}: {{trad|pl|śpiewać}}
+*{{por}}: {{trad|pt|cantar}}
+*{{rus}}: {{trad|ru|петь|(pet’)}}
+*{{sco}}: {{trad|sco|seinn}}
+*{{slv}}: {{trad|sl|peti}}
+*{{spa}}: {{trad|es|cantar}}
+*{{swe}}: {{trad|sv|sjunga}}
+*{{tur}}: {{trad|tr|şarkı söylemek}}
+*{{ukr}}: {{trad|uk|співати}}
+*{{vie}}: {{trad|vi|hát}}
+{{)}}
+===Referințe===
+* [http://dexonline.ro/ DEX online]

--- a/tests/test_ro.py
+++ b/tests/test_ro.py
@@ -11,6 +11,20 @@ from wikidict.utils import process_templates
     "word, pronunciations, etymology, definitions, variants",
     [
         (
+            "cânta",
+            [
+                "/kɨnˈta/",
+            ],
+            ["Din latină <i>cantare</i>."],
+            [
+                "(<i>v.intranz. și tranz.</i>) a emite cu vocea sau cu un instrument un șir de sunete muzicale care se rânduiesc într-o melodie, într-un acord etc.",  # noqa
+                "(<i>despre păsări, insecte etc.</i>) a scoate sunete plăcute la auz. caracteristice speciei.",
+                "(<i>v.intranz. și tranz.</i>) a scrie versuri în cinstea cuiva sau a ceva, a elogia (în versuri) pe cineva sau ceva; a descrie, a povesti ceva în versuri.",  # noqa
+                "(<i>v.tranz.</i>) (<i>fam.</i>) a îndruga, a înșira vorbe goale.",
+            ],
+            [],
+        ),
+        (
             "paronim",
             [
                 "/pa.ro'nim/",
@@ -45,7 +59,11 @@ def test_parse_word(
 
 @pytest.mark.parametrize(
     "wikicode, expected",
-    [],
+    [
+        ("{{n}}", "<i>n.</i>"),
+        ("{{p}}", "<i>pl.</i>"),
+        ("{{trad|el|παρα}}", "παρα"),
+    ],
 )
 def test_process_templates(wikicode: str, expected: str) -> None:
     """Test templates handling."""

--- a/wikidict/lang/ro/__init__.py
+++ b/wikidict/lang/ro/__init__.py
@@ -1,6 +1,6 @@
 """Romanian language."""
 import re
-from typing import List, Pattern, Tuple
+from typing import List, Pattern
 
 from ...user_functions import flatten, uniq
 
@@ -12,7 +12,6 @@ thousands_separator = "."
 
 # Markers for sections that contain interesting text to analyse.
 head_sections = ("{{limba|ron}}",)
-section_level = None
 section_sublevels = (3,)
 etyl_section = ("{{etimologie}}",)
 sections = (
@@ -37,8 +36,18 @@ sections = (
     "{{pronume}",
     "{{substantiv}",
     "{{sufix}",
-    "{{verb-}",
+    "{{verb}",
 )
+
+# Templates more complex to manage.
+templates_multi = {
+    # {{n}}
+    "n": "italic('n.')",
+    # {{p}}
+    "p": "italic('pl.')",
+    # {{trad|el|παρα}}
+    "trad": "parts[-1]",
+}
 
 # Release content on GitHub
 # https://github.com/BoboTiG/ebook-reader-dict/releases/tag/ro
@@ -85,21 +94,3 @@ def find_pronunciations(
     ['/ka.priˈmulg/']
     """
     return uniq(flatten(pattern.findall(code)))
-
-
-def last_template_handler(
-    template: Tuple[str, ...], locale: str, word: str = ""
-) -> str:
-    """
-    Will be call in utils.py::transform() when all template handlers were not used.
-
-    >>> last_template_handler(["trad", "el", "παρα"], "ca")
-    'παρα'
-
-    """
-    from ..defaults import last_template_handler as default
-
-    if template[0] == "trad":
-        return template[-1]
-
-    return default(template, locale, word=word)

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -358,6 +358,7 @@ def adjust_wikicode(code: str, locale: str) -> str:
     elif locale in ("it", "ro"):
         if locale == "ro":
             locale = "ron"
+
         # {{-avv-|it}} -> === {{avv}} ===
         code = re.sub(
             rf"^\{{\{{-(.+)-\|{locale}\}}\}}",


### PR DESCRIPTION
Related to  #1771.

I simply added a `assert 0, template` in `last_template_handler()` and added missing templates. I should have missed something because only 3 templates were found :)

Anyway, the number of rendered words went from `76,202` to `94,209` (out of `94,681`) 🍾 

I found missing verbs that are using subsections like https://ro.wiktionary.org/wiki/avea and https://ro.wiktionary.org/wiki/fi, will see later.

Also, I'm working on variants support right now.
