### PR TITLE
[EN] Fix missing lang aliases

### DIFF
--- a/scripts/en-langs.py
+++ b/scripts/en-langs.py
@@ -55,10 +55,6 @@ def read_all_lines_etym(lines: List[str]) -> Dict[str, Dict[str, str]]:
 
         concat += result + "\n"
     exec(concat, globals())
-    for k, v in m.copy().items():  # type: ignore # noqa
-        if alias_codes := v.get("alias_codes", {}):
-            for alias_code in alias_codes:
-                m[alias_code] = v  # type: ignore # noqa
     return m  # type: ignore # noqa
 
 

--- a/wikidict/lang/en/langs.py
+++ b/wikidict/lang/en/langs.py
@@ -9754,3 +9754,14 @@ langs = {
     "zzj": "Zuojiang Zhuang",
 }  # 9,747
 # END
+
+# Missings since 2024-02-28 (see #1999 and keep synced with https://en.wiktionary.org/wiki/Module:languages/data#L-196)
+langs["CL."] = langs["la-cla"]
+langs["EL."] = langs["la-ecc"]
+langs["LL."] = langs["la-lat"]
+langs["ML."] = langs["la-med"]
+langs["NL."] = langs["la-new"]
+langs["RL."] = langs["la-ren"]
+langs["VL."] = langs["la-vul"]
+langs["gkm-med"] = langs["gkm"]
+langs["prv"] = langs["oc-pro"]

--- a/wikidict/lang/en/template_handlers.py
+++ b/wikidict/lang/en/template_handlers.py
@@ -15,7 +15,7 @@ from ...user_functions import (
     term,
 )
 from .. import defaults
-from .labels import label_syntaxes
+from .labels import labels_subvarieties, label_syntaxes
 from .langs import langs
 from .places import (
     placetypes_aliases,
@@ -445,7 +445,7 @@ def render_foreign_derivation(tpl: str, parts: List[str], data: DefaultDict[str,
                 starter += " from"
         phrase = starter if data["nocap"] == "1" else starter.capitalize()
 
-    lang = "translingual" if dst_locale == "mul" else langs.get(dst_locale, "")
+    lang = "translingual" if dst_locale == "mul" else langs.get(dst_locale, "") or labels_subvarieties.get(dst_locale, "")
     phrase += lang if tpl not in mentions else ""
 
     if parts or data["3"]:

--- a/wikidict/lang/en/template_handlers.py
+++ b/wikidict/lang/en/template_handlers.py
@@ -15,7 +15,7 @@ from ...user_functions import (
     term,
 )
 from .. import defaults
-from .labels import labels_subvarieties, label_syntaxes
+from .labels import label_syntaxes
 from .langs import langs
 from .places import (
     placetypes_aliases,
@@ -445,7 +445,7 @@ def render_foreign_derivation(tpl: str, parts: List[str], data: DefaultDict[str,
                 starter += " from"
         phrase = starter if data["nocap"] == "1" else starter.capitalize()
 
-    lang = "translingual" if dst_locale == "mul" else langs.get(dst_locale, "") or labels_subvarieties.get(dst_locale, "")
+    lang = "translingual" if dst_locale == "mul" else langs.get(dst_locale, "")
     phrase += lang if tpl not in mentions else ""
 
     if parts or data["3"]:


### PR DESCRIPTION
I'm not sure this is a nice patch, but it fixes:

```python
>>> render_foreign_derivation("learned borrowing", ["en", "LL.", "trapezium"], defaultdict(str, {"notext":"1"}))
Expected:
    'Late Latin <i>trapezium</i>'
Got:
    '<i>trapezium</i>'
```