### PR TITLE
[EN] Support translingual section + partial "ISO 639" template

### DIFF
--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -15,6 +15,7 @@ from wikidict.utils import process_templates
             ["/æb/"],
             ["Abbreviation of <i>abdominal</i> <i>muscles</i>."],
             [
+                "ISO 639-1 code <b>1</b>",
                 "<i>(informal)</i> abdominal muscle. <small>[Mid 20<sup>th</sup> century.]</small>",
                 "<i>(slang)</i> An abscess caused by injecting an illegal drug, usually heroin.",
                 "<i>Abbreviation of</i> <b>abortion</b>.",
@@ -145,6 +146,7 @@ from wikidict.utils import process_templates
             ["/əːm/", "/ʌm/"],
             ["Onomatopoeic."],
             [
+                "micrometer; variant of μm used when the character μ is unavailable",
                 "<i>Expression of hesitation, uncertainty or space filler in conversation</i>. See uh.",
                 "<i>(chiefly US)</i> <i>Dated spelling of</i> <b>mmm</b>.",
                 "<i>(intransitive)</i> To make the <i>um</i> sound to express uncertainty or hesitancy.",

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -13,7 +13,7 @@ float_separator = "."
 thousands_separator = ","
 
 # Markers for sections that contain interesting text to analyse.
-head_sections = ("==English==", "english")
+head_sections = ("==English==", "english", "===Translingual===", "translingual")
 section_sublevels = (4, 3)
 etyl_section = ("Etymology", "Etymology 1")
 sections = (

--- a/wikidict/lang/en/template_handlers.py
+++ b/wikidict/lang/en/template_handlers.py
@@ -661,6 +661,24 @@ def render_ipa_char(tpl: str, parts: List[str], data: DefaultDict[str, str]) -> 
     return concat(parts, ", ")
 
 
+def render_iso_639(tpl: str, parts: List[str], data: DefaultDict[str, str]) -> str:
+    """
+    >>> render_iso_639("ISO 639", ["ja"], defaultdict(str, {}))
+    'ISO 639-1 code <b>ja</b>'
+    >>> render_iso_639("ISO 639", ["", "crk"], defaultdict(str, {}))
+    'ISO 639-2 code <b>crk</b>'
+    >>> render_iso_639("ISO 639", ["", "", "zho"], defaultdict(str, {}))
+    'ISO 639-3 code <b>zho</b>'
+    >>> render_iso_639("ISO 639", ["zh", "", "zho"], defaultdict(str, {"ref": "1"}))
+    'ISO 639-1 code <b>zh</b>, ISO 639-3 code <b>zho</b>'
+    """
+    codes = []
+    for idx, part in enumerate(parts, 1):
+        if part:
+            codes.append(f"ISO 639-{idx} code {strong(part)}")
+    return ", ".join(codes)
+
+
 def render_label(tpl: str, parts: List[str], data: DefaultDict[str, str]) -> str:
     """
     >>> render_label("label", ["en" , "Australia", "slang"], defaultdict(str, {"nocat":"1"}))
@@ -1341,6 +1359,7 @@ template_mapping = {
     "ic": render_ipa_char,
     "IPAchar": render_ipa_char,
     "ipachar": render_ipa_char,
+    "ISO 639": render_iso_639,
     "inh": render_foreign_derivation,
     "inh-lite": render_foreign_derivation,
     "inh+": render_foreign_derivation,


### PR DESCRIPTION
About the `ISO 639` template: https://en.wiktionary.org/wiki/Template:ISO_639/documentation
It is partially supported: it won't work for when the code is a number (yet?).