### PR TITLE
feat: optimized XML parser

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def craft_data() -> Callable[[str], bytes]:
     def _craft_data(locale: str) -> bytes:
         data_dir = Path(os.environ["CWD"]) / "data" / locale
         content = XML.format(locale=locale)
-        for file in data_dir.glob("*.wiki"):
+        for file in sorted(data_dir.glob("*.wiki")):
             if file.stem == "vide":
                 continue
 

--- a/wikidict/parse.py
+++ b/wikidict/parse.py
@@ -7,6 +7,7 @@ import re
 from collections import defaultdict
 from collections.abc import Generator
 from pathlib import Path
+from xml.sax.saxutils import unescape
 
 from .lang import head_sections
 
@@ -61,7 +62,7 @@ def process(file: Path, locale: str) -> dict[str, str]:
     for element in xml_iter_parse(file):
         word, code = xml_parse_element(element, locale)
         if word and code and ":" not in word:
-            words[word] = code
+            words[unescape(word)] = unescape(code)
 
     return words
 


### PR DESCRIPTION
The profiled code is:

```python
from time import monotonic
from pathlib import Path

from wikidict.parse import xml_iter_parse, xml_parse_element

file = Path("data/no/pages-20240901.xml")
start = monotonic()
for element in xml_iter_parse(file):
    xml_parse_element(element, "no")
end = monotonic()
print(end - start, "sec")
```

On my machine, parsing I got those values:

- Before: 3.10 sec
- After : 1.10 sec

---

I also run the "Update data" workflow to check for any regression. It appears, the new parser find more words, and it blazing fast :champagne: 

New *rendered* words:
- French: +1
- German: +1,296
- Greek: +1
- Italian: +2
- Russian: +1

Parsing times:
- all: at least divided by 2
- French: 3m27s -> 1m25s
- English: 5m20s -> 2m4s

---

It might be possible to improve even more, of course!

Finally, this patch also protects us against that kind of issue: #2060 :clinking_glasses: 