### PR TITLE
feat: improve how missing templates are reported

### DIFF
--- a/wikidict/check_word.py
+++ b/wikidict/check_word.py
@@ -15,7 +15,7 @@ import requests
 from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 from requests.exceptions import RequestException
 
-from .render import MISSING_TPL_SEEN, parse_word
+from .render import MISSING_TEMPLATES, parse_word
 from .stubs import Word
 from .user_functions import color, int_to_roman
 from .utils import get_random_word
@@ -393,4 +393,4 @@ def main(locale: str, word: str) -> int:
     word = word or get_random_word(locale)
 
     res = check_word(word, locale)
-    return 1 if "CI" in os.environ and MISSING_TPL_SEEN else res
+    return 1 if "CI" in os.environ and MISSING_TEMPLATES else res

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -89,17 +89,15 @@ def last_template_handler(template: tuple[str, ...], locale: str, word: str = ""
 
     # {{tpl|item1|item2|...}} -> ''
     if len(template) > 2:
-        from ..render import MISSING_TPL_SEEN
+        from ..render import MISSING_TEMPLATES
 
-        if tpl not in MISSING_TPL_SEEN:
-            MISSING_TPL_SEEN.append(tpl)
-            log.warning(" !! Missing %r template support for word %r", tpl, word)
+        MISSING_TEMPLATES.append((tpl, word))
         return ""
 
     # {{template}}
     from ..utils import CLOSE_DOUBLE_CURLY, OPEN_DOUBLE_CURLY
 
-    return f"{OPEN_DOUBLE_CURLY}{tpl}{CLOSE_DOUBLE_CURLY}" if tpl else ""
+    return f"{OPEN_DOUBLE_CURLY}{tpl}{CLOSE_DOUBLE_CURLY}"
 
 
 def render_wikilink(tpl: str, parts: list[str], data: defaultdict[str, str], word: str = "") -> str:


### PR DESCRIPTION
Missing templates are now printed at the end of the process, sorted by the total number of occurrences, and with 3 examples. It will ease prioritizing our work, eventually.

Example of output from the Greek dictionary:

    Missing 'λείπει η ετυμολογία' template support (45,707 times), example in: "Αϊδωνιά", "Αϊδώνα", "Αϊντίνι"
    Missing 'πρόσφ' template support (12,971 times), example in: "-δικείο", "-μάλλης", "-πλευρος"
    Missing 'μτφδ' template support (4,352 times), example in: "-γόνος", "-κέφαλος", "-καλλιέργεια"
    Missing 'δαν' template support (3,808 times), example in: "-άδα", "-άρω", "-έζος"
    Missing 'βλ' template support (3,581 times), example in: "'γγίζω", "-έλαιο", "-ήδικος"
    (...)
    Unhandled templates count: 117
