### PR TITLE
fix: remove problematic process-shared global variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,6 @@ def no_warnings(recwarn: pytest.WarningsRecorder) -> Generator[None]:
     warnings = []
     for warning in recwarn:  # pragma: no cover
         message = str(warning.message)
-        if "use of fork() may lead to deadlocks in the child" in message:
-            continue
         warn = f"{warning.filename}:{warning.lineno} {message}"
         print(warn, file=sys.stderr)
         warnings.append(warn)

--- a/tests/test_2_render.py
+++ b/tests/test_2_render.py
@@ -8,7 +8,6 @@ from wikitextparser import Section
 
 from wikidict import render
 from wikidict.stubs import Word
-from wikidict.utils import check_for_missing_templates
 
 
 def test_simple() -> None:
@@ -117,11 +116,6 @@ def test_adjust_wikicode(locale: str, code: str, expected: str) -> None:
 def test_missing_templates(workers: int, caplog: pytest.LogCaptureFixture) -> None:
     """Ensure the "missing templates" feature is working."""
 
-    # Clean-up the global, shared, list of missed templates from other tests
-    from wikidict.render import MISSING_TEMPLATES
-
-    MISSING_TEMPLATES[:] = []
-
     # Craft wikicode with unsupported templates
     in_words = {
         "a": """
@@ -147,15 +141,8 @@ def test_missing_templates(workers: int, caplog: pytest.LogCaptureFixture) -> No
 """,
     }
 
-    try:
-        # Render
-        words = render.render(in_words, "fr", workers)
-
-        # Call the missing templates checker
-        check_for_missing_templates()
-    finally:
-        # Prevent leaking false warnings to other tests
-        MISSING_TEMPLATES[:] = []
+    # Render
+    words = render.render(in_words, "fr", workers)
 
     # Check warnings
     warnings = [record.getMessage() for record in caplog.get_records("call") if record.levelno == logging.WARNING]

--- a/wikidict/check_word.py
+++ b/wikidict/check_word.py
@@ -404,7 +404,11 @@ def get_wiktionary_page(word: str, locale: str) -> str:
 
 
 def check_word(
-    word: str, locale: str, *, standalone: bool = True, missed_templates: list[tuple[str, str]] | None = None
+    word: str,
+    locale: str,
+    *,
+    standalone: bool = True,
+    missed_templates: list[tuple[str, str]] | None = None,
 ) -> int:
     errors = 0
     results: list[str] = []

--- a/wikidict/check_word.py
+++ b/wikidict/check_word.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import logging
-import os
 import re
 import urllib.parse
 import warnings
@@ -390,11 +389,11 @@ def get_url_content(url: str) -> str:
     raise RuntimeError(f"Sorry, too many tries for {url!r}")
 
 
-def get_word(word: str, locale: str) -> Word:
+def get_word(word: str, locale: str, *, missed_templates: list[tuple[str, str]] | None = None) -> Word:
     """Get a *word* wikicode and parse it."""
     url = craft_url(word, locale, raw=True)
     html = get_url_content(url)
-    return parse_word(word, html, locale)
+    return parse_word(word, html, locale, missed_templates=missed_templates)
 
 
 def get_wiktionary_page(word: str, locale: str) -> str:
@@ -404,12 +403,20 @@ def get_wiktionary_page(word: str, locale: str) -> str:
     return filter_html(html, locale)
 
 
-def check_word(word: str, locale: str) -> int:
+def check_word(
+    word: str, locale: str, *, standalone: bool = True, missed_templates: list[tuple[str, str]] | None = None
+) -> int:
     errors = 0
     results: list[str] = []
-    details = get_word(word, locale)
+
+    if missed_templates is None:
+        missed_templates = []
+
+    details = get_word(word, locale, missed_templates=missed_templates)
+
     if not details.etymology and not details.definitions:
-        return errors
+        return 0
+
     text = get_wiktionary_page(word, locale)
 
     if details.etymology:
@@ -442,6 +449,9 @@ def check_word(word: str, locale: str) -> int:
     else:
         log.debug("[%s] - OK", word)
 
+    if standalone:
+        errors += int(check_for_missing_templates(missed_templates))
+
     return errors
 
 
@@ -451,6 +461,4 @@ def main(locale: str, word: str) -> int:
     # If *word* is empty, get a random word
     word = word or get_random_word(locale)
 
-    res = check_word(word, locale)
-    res_missing_tpl = check_for_missing_templates()
-    return 1 if "CI" in os.environ and res_missing_tpl else res
+    return check_word(word, locale)

--- a/wikidict/get_word.py
+++ b/wikidict/get_word.py
@@ -11,12 +11,12 @@ from .user_functions import int_to_roman
 from .utils import check_for_missing_templates, convert_gender, convert_pronunciation, get_random_word
 
 
-def get_word(word: str, locale: str) -> Word:
+def get_word(word: str, locale: str, *, missed_templates: list[tuple[str, str]] | None = None) -> Word:
     """Get a *word* wikicode and parse it."""
     url = f"https://{locale}.wiktionary.org/w/index.php?title={word}&action=raw"
     with requests.get(url) as req:
         code = req.text
-    return parse_word(word, code, locale, force=True)
+    return parse_word(word, code, locale, force=True, missed_templates=missed_templates)
 
 
 def get_and_parse_word(word: str, locale: str, *, raw: bool = False) -> None:
@@ -37,7 +37,8 @@ def get_and_parse_word(word: str, locale: str, *, raw: bool = False) -> None:
         text = text.replace(" .", ".")
         return text
 
-    details = get_word(word, locale)
+    missed_templates: list[tuple[str, str]] = []
+    details = get_word(word, locale, missed_templates=missed_templates)
     print(
         word,
         convert_pronunciation(details.pronunciations).lstrip(),
@@ -73,6 +74,8 @@ def get_and_parse_word(word: str, locale: str, *, raw: bool = False) -> None:
     if details.variants:
         print("\n[variants]", ", ".join(iter(details.variants)))
 
+    check_for_missing_templates(missed_templates)
+
 
 def set_output(locale: str, word: str) -> None:
     """It is very specific to GitHub Actions, and will set the job summary with helpful information."""
@@ -89,5 +92,4 @@ def main(locale: str, word: str, *, raw: bool = False) -> int:
 
     set_output(locale, word)
     get_and_parse_word(word, locale, raw=raw)
-    check_for_missing_templates()
     return 0

--- a/wikidict/lang/ca/__init__.py
+++ b/wikidict/lang/ca/__init__.py
@@ -182,7 +182,13 @@ def find_pronunciations(
     return uniq(pattern.findall(code))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -414,4 +420,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if lang := langs.get(tpl, ""):
         return lang.capitalize()
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/da/__init__.py
+++ b/wikidict/lang/da/__init__.py
@@ -203,7 +203,13 @@ def find_pronunciations(
     return [item for sublist in (re.findall(pattern, code) or []) for item in sublist.split("|") if item]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -314,4 +320,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if not parts and (lang := langs.get(tpl)):
         return capitalize(lang)
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/de/__init__.py
+++ b/wikidict/lang/de/__init__.py
@@ -244,7 +244,13 @@ def find_pronunciations(
     return [f"[{p}]" for p in uniq(pattern.findall(code))]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -295,4 +301,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
         variant = data["1"] or data["Verb"] or parts[0]
         return variant.split("#", 1)[0]
 
-    return default(template, locale, word=word)
+    return default(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -58,7 +58,13 @@ def find_pronunciations(
     return []
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 
@@ -98,10 +104,11 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if italic := lookup_italic(tpl, locale, empty_default=True):
         return term(capitalize(italic))
 
-    from ..render import MISSING_TEMPLATES
+    if missed_templates is not None:
+        missed_templates.append((tpl, word))
+
     from ..utils import CLOSE_DOUBLE_CURLY, OPEN_DOUBLE_CURLY
 
-    MISSING_TEMPLATES.append((tpl, word))
     return f"{OPEN_DOUBLE_CURLY}{tpl}{CLOSE_DOUBLE_CURLY}"
 
 

--- a/wikidict/lang/el/__init__.py
+++ b/wikidict/lang/el/__init__.py
@@ -306,7 +306,13 @@ def labels_output(text_in: str, *, args: dict[str, str] = defaultdict(str)) -> s
     return mytext
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 
@@ -669,4 +675,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if tpl.startswith(("infl", "κλ", "θηλ του", "θηλ_του")):
         return parts[-1]
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -292,7 +292,13 @@ def find_pronunciations(
     return uniq(flatten(pattern.findall(code)))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 

--- a/wikidict/lang/eo/__init__.py
+++ b/wikidict/lang/eo/__init__.py
@@ -292,7 +292,13 @@ def find_pronunciations(
     ]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -305,4 +311,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if lookup_template(template[0]):
         return render_template(word, template)
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/es/__init__.py
+++ b/wikidict/lang/es/__init__.py
@@ -253,7 +253,13 @@ def find_pronunciations(
     return [f"[{p}]" for p in uniq(flatten(pattern.findall(code)))]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 
@@ -353,4 +359,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     ):
         return parts[0]
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/fr/__init__.py
+++ b/wikidict/lang/fr/__init__.py
@@ -602,7 +602,13 @@ def find_pronunciations(
     return [f"\\{p}\\" for p in uniq(pattern.findall(line))]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -971,4 +977,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if context := lookup_italic(tpl, locale, empty_default=True):
         return term(context)
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/it/__init__.py
+++ b/wikidict/lang/it/__init__.py
@@ -240,7 +240,13 @@ def find_pronunciations(
     return uniq(pattern.findall(code))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 
@@ -322,4 +328,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if lang := langs.get(tpl):
         return lang
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/no/__init__.py
+++ b/wikidict/lang/no/__init__.py
@@ -228,7 +228,13 @@ def find_pronunciations(
     return result
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -281,4 +287,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if not parts or (len(parts) == 1 and parts[0] in {"nb", "nn", "no", "nrm"}):
         return term(tpl)
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/pt/__init__.py
+++ b/wikidict/lang/pt/__init__.py
@@ -266,7 +266,13 @@ def find_pronunciations(
     return uniq(pattern.findall(code))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be call in utils.py::transform() when all template handlers were not used.
 
@@ -307,4 +313,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if lang := langs.get(tpl):
         return lang.capitalize()
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/ro/__init__.py
+++ b/wikidict/lang/ro/__init__.py
@@ -231,7 +231,13 @@ def find_pronunciations(code: str) -> list[str]:
     return uniq(flatten(res))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 

--- a/wikidict/lang/ru/__init__.py
+++ b/wikidict/lang/ru/__init__.py
@@ -120,7 +120,13 @@ def find_pronunciations(
     return uniq(pattern.findall(code))
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -240,4 +246,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if lang := langs.get(tpl):
         return lang
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/lang/sv/__init__.py
+++ b/wikidict/lang/sv/__init__.py
@@ -187,7 +187,13 @@ def find_pronunciations(
     return [f"/{p}/" for p in uniq(pattern.findall(code))]
 
 
-def last_template_handler(template: tuple[str, ...], locale: str, *, word: str = "") -> str:
+def last_template_handler(
+    template: tuple[str, ...],
+    locale: str,
+    *,
+    word: str = "",
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> str:
     """
     Will be called in utils.py::transform() when all template handlers were not used.
 
@@ -314,4 +320,4 @@ def last_template_handler(template: tuple[str, ...], locale: str, *, word: str =
     if tpl == "tr":
         return transliterate(parts[0], parts[1])
 
-    return defaults.last_template_handler(template, locale, word=word)
+    return defaults.last_template_handler(template, locale, word=word, missed_templates=missed_templates)

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -47,12 +47,6 @@ wikitextparser._spans.WIKILINK_PARAM_FINDITER = lambda *_: ()
 
 Sections = dict[str, list[wtp.Section]]
 
-# Multiprocessing shared globals, init in render() see #1054
-# TODO: at some point, we might want to change how we share data between pools (in-memory SQLite, redis, etc.)
-multiprocessing.set_start_method("fork", force=True)
-MANAGER = multiprocessing.Manager()
-MISSING_TEMPLATES: list[tuple[str, str]] = cast(list[tuple[str, str]], MANAGER.list())
-
 # To list all unhandled sections:
 #    DEBUG_SECTIONS=1 python -m wikidict LOCALE --render | sort -u >out.log
 #
@@ -65,11 +59,17 @@ DEBUG_SECTIONS = os.environ.get("DEBUG_SECTIONS", "0")
 log = logging.getLogger(__name__)
 
 
-def find_definitions(word: str, parsed_sections: Sections, locale: str) -> list[Definitions]:
+def find_definitions(
+    word: str,
+    parsed_sections: Sections,
+    locale: str,
+    *,
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> list[Definitions]:
     """Find all definitions, without eventual subtext."""
     definitions = list(
         chain.from_iterable(
-            find_section_definitions(word, section, locale)
+            find_section_definitions(word, section, locale, missed_templates=missed_templates)
             for sections in parsed_sections.values()
             for section in sections
         )
@@ -102,7 +102,13 @@ def es_replace_defs_list_with_numbered_lists(
     return regex_subitem.sub(r"\1## ", res)
 
 
-def find_section_definitions(word: str, section: wtp.Section, locale: str) -> list[Definitions]:
+def find_section_definitions(
+    word: str,
+    section: wtp.Section,
+    locale: str,
+    *,
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> list[Definitions]:
     """Find definitions from the given *section*, with eventual sub-definitions."""
     definitions: list[Definitions] = []
 
@@ -124,7 +130,7 @@ def find_section_definitions(word: str, section: wtp.Section, locale: str) -> li
                     continue
 
                 # Transform and clean the Wikicode
-                definition = process_templates(word, code, locale)
+                definition = process_templates(word, code, locale, missed_templates=missed_templates)
 
                 # Skip empty definitions
                 if not definition:
@@ -137,7 +143,7 @@ def find_section_definitions(word: str, section: wtp.Section, locale: str) -> li
                 subdefinitions: list[SubDefinitions] = []
                 for sublist in a_list.sublists(i=idx, pattern=sublist_patterns[locale]):
                     for idx2, subcode in enumerate(sublist.items):
-                        subdefinition = process_templates(word, subcode, locale)
+                        subdefinition = process_templates(word, subcode, locale, missed_templates=missed_templates)
                         if not subdefinition:
                             continue
 
@@ -145,7 +151,12 @@ def find_section_definitions(word: str, section: wtp.Section, locale: str) -> li
                         subsubdefinitions: list[str] = []
                         for subsublist in sublist.sublists(i=idx2, pattern=sublist_patterns[locale]):
                             for subsubcode in subsublist.items:
-                                if subsubdefinition := process_templates(word, subsubcode, locale):
+                                if subsubdefinition := process_templates(
+                                    word,
+                                    subsubcode,
+                                    locale,
+                                    missed_templates=missed_templates,
+                                ):
                                     subsubdefinitions.append(subsubdefinition)
                         if subsubdefinitions:
                             subdefinitions.append(tuple(subsubdefinitions))
@@ -155,7 +166,13 @@ def find_section_definitions(word: str, section: wtp.Section, locale: str) -> li
     return definitions
 
 
-def find_etymology(word: str, locale: str, parsed_section: wtp.Section) -> list[Definitions]:
+def find_etymology(
+    word: str,
+    locale: str,
+    parsed_section: wtp.Section,
+    *,
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> list[Definitions]:
     """Find the etymology."""
 
     def get_items(patterns: tuple[str, ...], *, skip: tuple[str, ...] | None = None) -> list[str]:
@@ -196,10 +213,15 @@ def find_etymology(word: str, locale: str, parsed_section: wtp.Section) -> list[
                         definitions.append(phrase)
                         tableindex += 1
                     else:
-                        definitions.append(process_templates(word, section_item, locale))
+                        definitions.append(
+                            process_templates(word, section_item, locale, missed_templates=missed_templates)
+                        )
                         subdefinitions: list[SubDefinitions] = []
                         for sublist in section.sublists(i=idx):
-                            subdefinitions.extend(process_templates(word, subcode, locale) for subcode in sublist.items)
+                            subdefinitions.extend(
+                                process_templates(word, subcode, locale, missed_templates=missed_templates)
+                                for subcode in sublist.items
+                            )
                         if subdefinitions:
                             definitions.append(tuple(subdefinitions))
             return definitions
@@ -214,7 +236,11 @@ def find_etymology(word: str, locale: str, parsed_section: wtp.Section) -> list[
         case "sv":
             items = re.findall(r"{{etymologi\|(.+)}}\s", parsed_section.contents)
 
-    return [etyl for item in items if (etyl := process_templates(word, item, locale)) and len(etyl) > 1]
+    return [
+        etyl
+        for item in items
+        if (etyl := process_templates(word, item, locale, missed_templates=missed_templates)) and len(etyl) > 1
+    ]
 
 
 def _find_genders(top_sections: list[wtp.Section], func: Callable[[str], list[str]]) -> list[str]:
@@ -588,7 +614,14 @@ def adjust_wikicode(code: str, locale: str) -> str:
     return code
 
 
-def parse_word(word: str, code: str, locale: str, *, force: bool = False) -> Word:
+def parse_word(
+    word: str,
+    code: str,
+    locale: str,
+    *,
+    force: bool = False,
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> Word:
     """Parse *code* Wikicode to find word details.
     *force* can be set to True to force the pronunciation and gender guessing.
     It is disabled by default to speed-up the overall process, but enabled when
@@ -604,17 +637,17 @@ def parse_word(word: str, code: str, locale: str, *, force: bool = False) -> Wor
     # Etymology
     if locale == "sv":
         for top in top_sections:
-            etymology.extend(find_etymology(word, locale, top))
+            etymology.extend(find_etymology(word, locale, top, missed_templates=missed_templates))
     elif parsed_sections:
         for section in etyl_section[locale]:
             if not parsed_sections:
                 break
             for etyl_data in parsed_sections.pop(section, []):
-                etymology.extend(find_etymology(word, locale, etyl_data))
+                etymology.extend(find_etymology(word, locale, etyl_data, missed_templates=missed_templates))
 
     # Definitions
     if parsed_sections:
-        definitions = find_definitions(word, parsed_sections, locale)
+        definitions = find_definitions(word, parsed_sections, locale, missed_templates=missed_templates)
     elif locale in {"no", "pt"}:
         # Some words have no head sections but only a list of definitions at the root of the "top" section
         marker = {
@@ -657,25 +690,39 @@ def load(file: Path) -> dict[str, str]:
     return words
 
 
-def render_word(w: list[str], words: Words, locale: str) -> Word | None:
+def render_word(
+    w: list[str],
+    words: Words,
+    locale: str,
+    *,
+    missed_templates: list[tuple[str, str]] | None = None,
+) -> Word | None:
     word, code = w
-    with suppress(KeyboardInterrupt):
-        try:
-            details = parse_word(word, code, locale)
-        except Exception:  # pragma: nocover
-            log.exception("ERROR with %r", word)
-        else:
-            if details.definitions or details.variants:
-                words[word] = details
-                return details
+    try:
+        details = parse_word(word, code, locale, missed_templates=missed_templates)
+    except KeyboardInterrupt:
+        pass
+    except Exception:  # pragma: nocover
+        log.exception("ERROR with %r", word)
+    else:
+        if details.definitions or details.variants:
+            words[word] = details
+            return details
     return None
 
 
 def render(in_words: dict[str, str], locale: str, workers: int) -> Words:
-    results: Words = cast(dict[str, Word], MANAGER.dict())
+    manager = multiprocessing.Manager()
+    results: Words = cast(dict[str, Word], manager.dict())
+    missed_templates: list[tuple[str, str]] = cast(list[tuple[str, str]], manager.list())
 
     with suppress(KeyboardInterrupt), multiprocessing.Pool(processes=workers) as pool:
-        pool.map(partial(render_word, words=results, locale=locale), in_words.items())
+        pool.map(
+            partial(render_word, words=results, locale=locale, missed_templates=missed_templates),
+            in_words.items(),
+        )
+
+    check_for_missing_templates(list(missed_templates))
 
     return results.copy()
 
@@ -710,8 +757,6 @@ def main(locale: str, *, workers: int = multiprocessing.cpu_count()) -> int:
     words = render(in_words, locale, workers)
     if not words:
         raise ValueError("Empty dictionary?!")
-
-    check_for_missing_templates()
 
     date = file.stem.split("-")[1]
     save(date, words, output_dir)


### PR DESCRIPTION
Definitively fixes #1054, and simplify the thinking process while adding more explicit code.

It seems a lot of code, maybe that's not the best approach, but at least it feels more proper & explicit: I added the `missed_templates` keyword-argument from top calls until the lowest function. It will work either with a simple list (like when used from `--get-word`, or `--check-word`), a shared `multiprocessing` object (like in `--render`), and it does not break other code since it is `None` by default.
No more global variables, and I tested with all `multiprocessing` start methods (fork, forkserver, and spawn): they all work.

Bonus points:
- `--check-words` now reports missed templates
- no more side-effects in tests: each run has its own `missed_template` value (as seen in `test_2_render.py` clean-up)