### PR TITLE
feat(experimental): change the way we check for head sections

### DIFF
--- a/wikidict/lang/da/__init__.py
+++ b/wikidict/lang/da/__init__.py
@@ -11,7 +11,7 @@ thousands_separator = " "
 # Markers for sections that contain interesting text to analyse.
 section_patterns = ("#", r"\*")
 section_sublevels = (3, 4)
-head_sections = ("{{da}}", "=dansk", "= dansk", "{{=da=}}", "{{-da-}}", "{{mul}}", "{{=mul=}}", "{{-mul-}}")
+head_sections = ("{{da}}", "{{=da=}}", "{{-da-}}", "dansk", "{{mul}}", "{{=mul=}}", "{{-mul-}}")
 etyl_section = ("{{etym}}", "{{etym2}}", "etymologi", "etymologi 1", "etymologi 2", "etymologi 3", "etymologi 4")
 sections = (
     *etyl_section,

--- a/wikidict/lang/en/__init__.py
+++ b/wikidict/lang/en/__init__.py
@@ -12,7 +12,7 @@ float_separator = "."
 thousands_separator = ","
 
 # Markers for sections that contain interesting text to analyse.
-head_sections = ("==english==", "english", "===translingual===", "translingual")
+head_sections = ("english", "translingual")
 section_sublevels = (4, 3)
 etyl_section = ("etymology", "etymology 1")
 sections = (

--- a/wikidict/lang/sv/__init__.py
+++ b/wikidict/lang/sv/__init__.py
@@ -12,7 +12,7 @@ thousands_separator = " "
 
 # Markers for sections that contain interesting text to analyse.
 # https://sv.wiktionary.org/wiki/Wiktionary:Stilguide#Ordklassrubriken
-head_sections = ("==svenska==", "svenska")
+head_sections = ("svenska",)
 sections = (
     "adjektiv",
     "adverb",

--- a/wikidict/parse.py
+++ b/wikidict/parse.py
@@ -48,10 +48,10 @@ def xml_iter_parse(file: Path) -> Generator[str]:
 def xml_parse_element(element: str, locale: str) -> tuple[str, str]:
     """Parse the XML `element` to retrieve the word and its definitions."""
     if title_match := next(RE_TITLE(element), None):
+        head_sections_match = re.compile(rf"^=*\s*({'|'.join(head_sections[locale])})", flags=re.IGNORECASE | re.MULTILINE).finditer
         for text_match in RE_TEXT(element, pos=element.find("<text", title_match.endpos)):
             wikicode = text_match[1]
-            wikicode_lowercase = wikicode.lower()
-            if any(section in wikicode_lowercase for section in head_sections[locale]):
+            if next(head_sections_match(wikicode), None):
                 return title_match[1], wikicode
 
         if DEBUG_PARSE:

--- a/wikidict/parse.py
+++ b/wikidict/parse.py
@@ -68,7 +68,7 @@ def process(file: Path, locale: str) -> dict[str, str]:
 
     log.info("Processing %s ...", file)
 
-    if locale in {"ca", "da", "el", "en", "eo", "it", "no", "pt", "sv"}:
+    if locale in {"ca", "da", "el", "en", "it", "no", "pt", "sv"}:
         # For several locales it is more accurate to use a regexp matcher
         head_sections_matcher = re.compile(
             rf"^=*\s*({'|'.join(head_sections[locale])})",
@@ -76,7 +76,7 @@ def process(file: Path, locale: str) -> dict[str, str]:
         ).finditer
     else:
         # While for others, a simple check is better because it is either more accurate, or simply impossible to rely on the former
-        assert locale in {"de", "es", "fr", "fro", "ro", "ru"}
+        assert locale in {"de", "es", "eo", "fr", "fro", "ro", "ru"}
 
         def head_sections_matcher(wikicode: str) -> Iterator[str]:  # type: ignore[misc]
             return (s for s in head_sections[locale] if s in wikicode.lower())

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -488,7 +488,7 @@ def adjust_wikicode(code: str, locale: str) -> str:
         # {{=da=}} → =={{da}}==
         code = re.sub(r"\{\{=(\w+)=\}\}", r"=={{\1}}==", code, flags=re.MULTILINE)
 
-        # ===dansk==== → =={{da}}==
+        # ===dansk=== → =={{da}}==
         code = re.sub(r"=+\s*[Dd]ansk\s*=+", r"=={{da}}==", code, flags=re.MULTILINE)
 
         # Transform sub-locales into their own section to prevent mixing stuff


### PR DESCRIPTION
For several locales it is more accurate to use a regexp matcher:
- CA,DA,EL,EN,EO,IT,NO,PT,SV: more accurate parsing (remove false positives or no change)

While for others, a simple check is better because it is either more accurate, or simply impossible to rely on the former.

Fixes #2374.
