### PR TITLE
fix: variants support for "tricky" cases

### DIFF
--- a/tests/test_3_convert.py
+++ b/tests/test_3_convert.py
@@ -34,7 +34,7 @@ Version sans étymologies :
 Mis à jour le"""
 
 WORDS = {
-    "empty": Word.empty(),
+    "empty": Word([], [], [], [], []),
     "foo": Word(["pron"], ["gender"], ["etyl"], ["def 1", ("sdef 1",)], []),
     "foos": Word(["pron"], ["gender"], ["etyl"], ["def 1", ("sdef 1", ("ssdef 1",))], ["baz"]),
     "baz": Word(["pron"], ["gender"], ["etyl"], ["def 1", ("sdef 1",)], ["foobar"]),
@@ -296,6 +296,95 @@ def test_word_rendering(
         include_etymology=include_etymology,
     )
 
-    kwargs = {"name": "mu", "words": WORDS} if isinstance(cls, convert.KoboFormat) else {}
-    content = next(cls.handle_word("Multiple Etymologies", WORDS["Multiple Etymologies"], **kwargs))
+    content = next(cls.handle_word("Multiple Etymologies", WORDS["Multiple Etymologies"], WORDS))
     assert content == expected
+
+
+WORDS_VARIANTS_FR = words = {
+    "être": Word(
+        pronunciations=["\\ɛtʁ\\"],
+        genders=["m"],
+        etymology=["<i>(Date à préciser)</i> Du moyen français <i>estre</i> ..."],
+        definitions=[
+            "Définir un état, une caractéristique du sujet.",
+            "Se situer, se trouver, rester, spécifiant une location, une situation.",
+            "<i>(Absolument)</i> Exister.",
+        ],
+        variants=[],
+    ),
+    "suis": Word(
+        pronunciations=["\\sɥi\\"],
+        genders=[],
+        etymology=["<i>(Forme de verbe 1)</i> De l’ancien français <i>suis</i>..."],
+        definitions=[],
+        variants=["suivre", "être", "foo"],
+    ),
+    "suivre": Word(
+        pronunciations=["\\sɥivʁ\\"],
+        genders=[],
+        etymology=[
+            "<i>(Date à préciser)</i> Du moyen français...",
+            "Les parentés proches de ce mot incluent, ...",
+        ],
+        definitions=[
+            "Aller ou venir après.",
+            "Aller, continuer d’aller dans une même direction.",
+            ("S’emploie figurément dans le même sens.",),
+        ],
+        variants=[],
+    ),
+}
+WORDS_VARIANTS_ES = {
+    "gastada": Word(pronunciations=[], genders=[], etymology=[], definitions=[], variants=["gastado"]),
+    "gastado": Word(pronunciations=[], genders=[], etymology=[], definitions=[], variants=["gastar"]),
+    "gastar": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=['Del latín <i>vastāre</i> ("devastar").'],
+        definitions=[
+            "Provocar el consumo, deterioro o destrucción de algo por el uso.",
+            "Digerir, asimilar los alimentos.",
+        ],
+        variants=[],
+    ),
+}
+
+
+def test_make_variants() -> None:
+    assert convert.make_variants(WORDS_VARIANTS_FR) == {"foo": ["suis"], "suivre": ["suis"], "être": ["suis"]}
+    assert convert.make_variants(WORDS_VARIANTS_ES) == {"gastado": ["gastada"], "gastar": ["gastado"]}
+
+
+def test_kobo_format_variants_different_prefix(tmp_path: Path) -> None:
+    words = WORDS_VARIANTS_FR
+    variants = convert.make_variants(words)
+    kobo_formater = convert.KoboFormat("fr", tmp_path, words, variants, "20250322")
+
+    assert kobo_formater.make_groups(words) == {
+        "su": {"suis": words["suis"], "suivre": words["suivre"]},
+        "êt": {"être": words["être"]},
+    }
+
+    assert "variant" not in "".join(kobo_formater.handle_word("suis", words["suis"], words))
+    assert '<variant name="suis"/></var>' in "".join(kobo_formater.handle_word("être", words["être"], words))
+    assert '<variant name="suis"/></var>' in "".join(kobo_formater.handle_word("suivre", words["suivre"], words))
+
+
+def test_kobo_format_variants_empty_variant_level_1(tmp_path: Path) -> None:
+    words = WORDS_VARIANTS_ES
+    variants = convert.make_variants(words)
+    kobo_formater = convert.KoboFormat("es", tmp_path, words, variants, "20250322")
+
+    assert kobo_formater.make_groups(words) == {
+        "ga": {
+            "gastada": words["gastada"],
+            "gastado": words["gastado"],
+            "gastar": words["gastar"],
+        }
+    }
+
+    assert "variant" not in "".join(kobo_formater.handle_word("gastada", words["gastada"], words))
+    assert "variant" not in "".join(kobo_formater.handle_word("gastado", words["gastado"], words))
+    assert '<variant name="gastada"/><variant name="gastado"/></var>' in "".join(
+        kobo_formater.handle_word("gastar", words["gastar"], words)
+    )

--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -85,13 +85,19 @@ WORD_TPL_KOBO = Template(
         {% endif %}
     </p>
     {% if variants %}
-        {{ variants }}
+        <var>
+        {%- for variant in variants -%}
+            <variant name="{{ variant }}"/>
+        {%- endfor -%}
+        </var>
     {% endif %}
 </w>
 """
 )
 
 # DictFile-related dictionaries
+# Source: https://pgaskin.net/dictutil/dictgen/#dictfile-format
+# Source: https://github.com/hunspell/hunspell/blob/ecc6dbb52025bdf3a766429988e64190d912765f/man/hunspell.1#L93-L139 (for later, in case of issues with other sub-formats)
 WORD_TPL_DICTFILE = Template(
     """\
 @ {{ word }}
@@ -149,14 +155,7 @@ log = logging.getLogger(__name__)
 class BaseFormat:
     """Base class for all dictionaries."""
 
-    __slots__ = {
-        "locale",
-        "output_dir",
-        "snapshot",
-        "words",
-        "variants",
-        "include_etymology",
-    }
+    template = Template("")  # To be set by subclasses
 
     def __init__(
         self,
@@ -188,8 +187,37 @@ class BaseFormat:
             self.locale, "" if self.include_etymology else constants.NO_ETYMOLOGY_SUFFIX
         )
 
-    def handle_word(self, word: str, details: Word, **kwargs: Any) -> Generator[str]:  # pragma: nocover
-        raise NotImplementedError()
+    def handle_word(self, word: str, details: Word, words: Words) -> Generator[str]:
+        if not details.definitions:
+            return
+
+        variants_final = []
+
+        if variants := self.variants.get(word, []):
+            # Add variants of empty* variant, only 1 redirection:
+            #   [ES] gastada* -> gastado* -> gastar --> (gastada, gastado) -> gastar
+            # Note: the process works backward: from gastar up to gastado up to gastada.
+            for variant in variants.copy():
+                if (wv := words.get(variant)) and not wv.definitions:
+                    variants.extend(self.variants.get(variant, []))
+
+            if isinstance(self, KoboFormat):
+                # Variant must be normalized by trimming whitespace and lowercasing it.
+                variants = [variant.lower().strip() for variant in variants]
+
+            # Remove potential duplicates, and sort by length then name
+            variants_final = sorted(set(variants), key=lambda s: (len(s), s))
+
+        yield self.render_word(
+            self.template,
+            word=word,
+            current_word=word,
+            definitions=details.definitions,
+            pronunciation=convert_pronunciation(details.pronunciations),
+            gender=convert_gender(details.genders),
+            etymologies=details.etymology if self.include_etymology else [],
+            variants=variants_final,
+        )
 
     def process(self) -> None:  # pragma: nocover
         raise NotImplementedError()
@@ -213,6 +241,7 @@ class KoboFormat(BaseFormat):
     """Save the data into Kobo-specific ZIP file."""
 
     output_file = "dicthtml-{0}-{0}{1}.zip"
+    template = WORD_TPL_KOBO
 
     def process(self) -> None:
         self.groups = self.make_groups(self.words)
@@ -250,76 +279,6 @@ class KoboFormat(BaseFormat):
         for word, details in words.items():
             groups[guess_prefix(word)][word] = details
         return groups
-
-    def handle_word(self, word: str, details: Word, **kwargs: Any) -> Generator[str]:
-        name: str = kwargs["name"]
-        words: Words = kwargs["words"]
-        current_words: Words = {word: details}
-
-        # use variant definitions for a word if one variant prefix is different
-        # "suis" listed with the definitions of "être" and "suivre"
-        if details.variants:
-            found_different_prefix = False
-            for variant in details.variants:
-                if guess_prefix(variant) != name:
-                    if root_details := self.words.get(variant):
-                        found_different_prefix = True
-                        break
-            variants_words = {}
-            # if we found one variant, then list them all
-            if found_different_prefix:
-                for variant in details.variants:
-                    if root_details := self.words.get(variant):
-                        variants_words[variant] = root_details
-            if word.endswith("s"):  # crude detection of plural
-                singular = word[:-1]
-                maybe_noun = self.words.get(singular)  # do we have the singular?
-                # make sure we are not redirecting to a verb (je mange, tu manges)
-                # verb form is also a singular noun
-                if isinstance(maybe_noun, Word) and not maybe_noun.variants:
-                    variants_words[singular] = maybe_noun
-                    for variant in details.variants:
-                        if maybe_verb := self.words.get(variant):
-                            variants_words[variant] = maybe_verb
-            if variants_words:
-                current_words = variants_words
-
-        # write to file
-        for current_word, current_details in current_words.items():
-            if not current_details.definitions:
-                continue
-
-            variants = ""
-            if word_variants := self.variants.get(word, []):
-                # add variants of empty* variant, only 1 redirection...
-                # gastada* -> gastado* -> gastar --> (gastada, gastado) -> gastar
-                for v in word_variants.copy():
-                    wv: Word = words.get(v, Word.empty())
-                    if wv and not wv.definitions:
-                        for vv in self.variants.get(v, []):
-                            word_variants.append(vv)
-                word_variants.sort(key=lambda s: (len(s), s))
-                variants = "<var>"
-                for v in word_variants:
-                    # no variant with different prefix
-                    v = v.lower().strip()
-                    if guess_prefix(v) == name:
-                        variants += f'<variant name="{v}"/>'
-                variants += "</var>"
-            # no empty var tag
-            if len(variants) < 15:
-                variants = ""
-
-            yield self.render_word(
-                WORD_TPL_KOBO,
-                word=word,
-                current_word=current_word,
-                definitions=current_details.definitions,
-                pronunciation=convert_pronunciation(current_details.pronunciations),
-                gender=convert_gender(current_details.genders),
-                etymologies=current_details.etymology if self.include_etymology else [],
-                variants=variants,
-            )
 
     def save(self) -> None:  # sourcery skip: extract-method
         """
@@ -394,7 +353,7 @@ class KoboFormat(BaseFormat):
         raw_output = output_dir / f"{name}.raw.html"
         with raw_output.open(mode="w", encoding="utf-8") as fh:
             for word, details in words.items():
-                fh.writelines(self.handle_word(word, details, name=name, words=words))
+                fh.writelines(self.handle_word(word, details, words))
 
         # Compress the HTML with gzip
         output = output_dir / f"{name}.html"
@@ -408,24 +367,13 @@ class DictFileFormat(BaseFormat):
     """Save the data into a *.df* DictFile."""
 
     output_file = "dict-{0}-{0}{1}.df"
-
-    def handle_word(self, word: str, details: Word, **kwargs: Any) -> Generator[str]:
-        if details.definitions:
-            yield self.render_word(
-                WORD_TPL_DICTFILE,
-                word=word,
-                definitions=details.definitions,
-                pronunciation=convert_pronunciation(details.pronunciations),
-                gender=convert_gender(details.genders),
-                etymologies=details.etymology if self.include_etymology else [],
-                variants=self.variants.get(word, []),
-            )
+    template = WORD_TPL_DICTFILE
 
     def process(self) -> None:
         file = self.dictionary_file(self.output_file)
         with file.open(mode="w", encoding="utf-8") as fh:
             for word, details in self.words.items():
-                fh.writelines(self.handle_word(word, details))
+                fh.writelines(self.handle_word(word, details, self.words))
 
         self.summary(file)
 
@@ -688,10 +636,8 @@ def make_variants(words: Words) -> Variants:
     """Group word by variant."""
     variants: Variants = defaultdict(list)
     for word, details in words.items():
-        # Variant must be normalized by trimming whitespace and lowercasing it.
         for variant in details.variants:
-            if variant:
-                variants[variant].append(word)
+            variants[variant].append(word)
     return variants
 
 

--- a/wikidict/stubs.py
+++ b/wikidict/stubs.py
@@ -15,10 +15,6 @@ class Word(NamedTuple):
     definitions: list[Definitions]
     variants: list[str]
 
-    @classmethod
-    def empty(cls) -> "Word":
-        return cls([], [], [], [], [])
-
 
 Words = dict[str, Word]
 Groups = dict[str, Words]


### PR DESCRIPTION
- Add regression tests to ensure current behavior is respected, and prevent future breakings.
- [Kobo] Variants from different prefix groups were ignored (like in FR with "suis" which is a variant of "être"). As the device will ignore variants from different prefix group, I deleted the code to simplify the logic. It seems harlmess.
- Fix variants pointing to an empty word itself pointing to another variant (only 1 level supported).
- Variants are passed as a list of `str` to templates, allowing to merge the code for Kobo & DictFile formats.
- Variants special cases are now also made available to DictFile, and its sub-formats.
- The code to handle variants is greatly simplified now.
- Removed the no more used `Word.empty()`.

Fixes #
