### PR TITLE
feat: support "reverse variants" (inflexions tables)

### DIFF
--- a/tests/test_2_render.py
+++ b/tests/test_2_render.py
@@ -135,6 +135,7 @@ def test_missing_templates(keep_unfinished: bool, workers: int, caplog: pytest.L
                 ]
             },
             variants=[],
+            reverse_variants=[],
         ),
         "b": Word(
             pronunciations=[],
@@ -144,6 +145,7 @@ def test_missing_templates(keep_unfinished: bool, workers: int, caplog: pytest.L
                 "Lettre": ["Deuxième lettre et première consonne de l’alphabet latin (minuscule). {{unknown-1}}."]
             },
             variants=[],
+            reverse_variants=[],
         ),
         "c": Word(
             pronunciations=[],
@@ -156,6 +158,7 @@ def test_missing_templates(keep_unfinished: bool, workers: int, caplog: pytest.L
                 ]
             },
             variants=[],
+            reverse_variants=[],
         ),
     }
 

--- a/tests/test_3_convert.py
+++ b/tests/test_3_convert.py
@@ -15,17 +15,18 @@ from wikidict.constants import ASSET_CHECKSUM_ALGO
 from wikidict.stubs import Variants, Word, Words
 
 WORDS = {
-    "empty": Word([], [], [], {}, []),
-    "foo": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1",)]}, []),
-    "foos": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1", ("ssdef 1",))]}, ["baz"]),
-    "baz": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1",)]}, ["foobar"]),
-    "empty1": Word([], [], [], {}, ["foo"]),
-    "empty2": Word([], [], [], {}, ["empty1"]),
+    "empty": Word([], [], [], {}, [], []),
+    "foo": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1",)]}, [], []),
+    "foos": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1", ("ssdef 1",))]}, ["baz"], []),
+    "baz": Word(["pron"], ["gender"], ["etyl"], {"Noun": ["def 1", ("sdef 1",)]}, ["foobar"], []),
+    "empty1": Word([], [], [], {}, ["foo"], []),
+    "empty2": Word([], [], [], {}, ["empty1"], []),
     "Multiple Etymologies": Word(
         ["pron"],
         ["gender"],
         ["etyl 1", ("setyl 1",)],
         {"Noun": ["def 1", ("sdef 1",)]},
+        [],
         [],
     ),
     "Multiple Etymology": Word(
@@ -34,6 +35,7 @@ WORDS = {
         ["etyl0"],
         {"Noun": ["def 0"]},
         ["Multiple Etymologies"],
+        [],
     ),
     "GIF": Word(
         ["pron"],
@@ -50,6 +52,7 @@ WORDS = {
             ]
         },
         ["gif"],
+        [],
     ),
 }
 
@@ -385,6 +388,7 @@ WORDS_VARIANTS_FR = words = {
         etymology=[],
         definitions={"Verbe": ["Définition de 'estre'."]},
         variants=[],
+        reverse_variants=[],
     ),
     "être": Word(
         pronunciations=["\\ɛtʁ\\"],
@@ -396,6 +400,7 @@ WORDS_VARIANTS_FR = words = {
             ]
         },
         variants=[],
+        reverse_variants=[],
     ),
     "suis": Word(
         pronunciations=["\\sɥi\\"],
@@ -403,6 +408,7 @@ WORDS_VARIANTS_FR = words = {
         etymology=[],
         definitions={},
         variants=["suivre", "être", "estre"],
+        reverse_variants=[],
     ),
     "suivre": Word(
         pronunciations=["\\sɥivʁ\\"],
@@ -410,29 +416,67 @@ WORDS_VARIANTS_FR = words = {
         etymology=[],
         definitions={"Verbe": ["Définition de 'suivre'."]},
         variants=[],
+        reverse_variants=[],
     ),
 }
 WORDS_VARIANTS_ES = {
-    "gastadan": Word(pronunciations=[], genders=[], etymology=[], definitions={}, variants=["gastada"]),
-    "gastada": Word(pronunciations=[], genders=[], etymology=[], definitions={}, variants=["gastado"]),
-    "gastado": Word(pronunciations=[], genders=[], etymology=[], definitions={}, variants=["gastar"]),
+    "gastadan": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=[],
+        definitions={},
+        variants=["gastada"],
+        reverse_variants=[],
+    ),
+    "gastada": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=[],
+        definitions={},
+        variants=["gastado"],
+        reverse_variants=[],
+    ),
+    "gastado": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=[],
+        definitions={},
+        variants=["gastar"],
+        reverse_variants=[],
+    ),
     "gastar": Word(
         pronunciations=[],
         genders=[],
         etymology=[],
         definitions={"Verb": ["Definition of 'gastar'."]},
         variants=[],
+        reverse_variants=[],
     ),
 }
 WORDS_VARIANTS_ES_2 = {
-    "-foba": Word(pronunciations=[], genders=[], etymology=[], definitions={}, variants=["-fobo"]),
-    "-fobas": Word(pronunciations=[], genders=[], etymology=[], definitions={}, variants=["-foba", "-fobo"]),
+    "-foba": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=[],
+        definitions={},
+        variants=["-fobo"],
+        reverse_variants=[],
+    ),
+    "-fobas": Word(
+        pronunciations=[],
+        genders=[],
+        etymology=[],
+        definitions={},
+        variants=["-foba", "-fobo"],
+        reverse_variants=[],
+    ),
     "-fobo": Word(
         pronunciations=[],
         genders=[],
         etymology=[],
         definitions={"Suffix": ["-phobe", "-phobic"]},
         variants=[],
+        reverse_variants=[],
     ),
 }
 

--- a/tests/test_ro.py
+++ b/tests/test_ro.py
@@ -8,7 +8,7 @@ from wikidict.utils import process_templates
 
 
 @pytest.mark.parametrize(
-    "word, pronunciations, etymology, definitions, variants",
+    "word, pronunciations, etymology, definitions, variants, reverse_variants",
     [
         (
             "aventurierul",
@@ -16,6 +16,7 @@ from wikidict.utils import process_templates
             [],
             {},
             ["aventurier"],
+            [],
         ),
         (
             "cânta",
@@ -31,6 +32,7 @@ from wikidict.utils import process_templates
                 ],
             },
             [],
+            ["cânt", "cântat", "cânte"],
         ),
         (
             "fi",
@@ -64,9 +66,22 @@ from wikidict.utils import process_templates
                 ]
             },
             [],
+            ["fie", "fost", "sunt"],
         ),
-        ("frumoasă", ["/fru'mo̯a.sə/"], [], {}, ["frumos"]),
-        ("frumoși", ["[fruˈmoʃʲ]"], [], {}, ["frumos"]),
+        ("frumoasă", ["/fru'mo̯a.sə/"], [], {}, ["frumos"], []),
+        ("frumoși", ["[fruˈmoʃʲ]"], [], {}, ["frumos"], []),
+        (
+            "Lama",
+            [],
+            [],
+            {
+                "Nume Taxonomic": [
+                    "(<i>zool.</i>) gen de animale din familia <i>Camelidae</i>; (<i>spec.</i>) lamă, guanaco"
+                ]
+            },
+            [],
+            [],
+        ),
         (
             "paronim",
             ["/pa.ro'nim/"],
@@ -80,17 +95,7 @@ from wikidict.utils import process_templates
                 ]
             },
             [],
-        ),
-        (
-            "Lama",
-            [],
-            [],
-            {
-                "Nume Taxonomic": [
-                    "(<i>zool.</i>) gen de animale din familia <i>Camelidae</i>; (<i>spec.</i>) lamă, guanaco"
-                ]
-            },
-            [],
+            ["paronime", "paronimele", "paronimelor", "paronimul", "paronimului"],
         ),
         (
             "MHz",
@@ -98,8 +103,9 @@ from wikidict.utils import process_templates
             [],
             {"Simbol": ["simbol pentru megahertz"]},
             [],
+            [],
         ),
-        ("portocale", ["/por.toˈka.le/"], [], {}, ["portocală"]),
+        ("portocale", ["/por.toˈka.le/"], [], {}, ["portocală"], []),
         (
             "temperatură",
             ["/tem.pe.raˈtu.rə/"],
@@ -116,6 +122,7 @@ from wikidict.utils import process_templates
                 ],
             },
             [],
+            ["temperatura", "temperaturi", "temperaturii", "temperaturile", "temperaturilor"],
         ),
     ],
 )
@@ -125,6 +132,7 @@ def test_parse_word(
     etymology: list[Definitions],
     definitions: list[Definitions],
     variants: list[str],
+    reverse_variants: list[str],
     page: Callable[[str, str], str],
 ) -> None:
     """Test the sections finder and definitions getter."""
@@ -134,6 +142,7 @@ def test_parse_word(
     assert etymology == details.etymology
     assert definitions == details.definitions
     assert variants == details.variants
+    assert reverse_variants == details.reverse_variants
 
 
 @pytest.mark.parametrize(

--- a/wikidict/get_word.py
+++ b/wikidict/get_word.py
@@ -93,6 +93,9 @@ def get_and_parse_word(word: str, locale: str, *, raw: bool = False) -> None:
     if details.variants:
         print("\n[variants]", ", ".join(iter(details.variants)))
 
+    if details.reverse_variants:
+        print("\n[reverse variants]", ", ".join(iter(details.reverse_variants)))
+
     print()
     utils.check_for_missing_templates(all_templates)
 

--- a/wikidict/lang/__init__.py
+++ b/wikidict/lang/__init__.py
@@ -42,8 +42,10 @@ sections: dict[str, tuple[str, ...]] = _populate("sections")
 # Variants
 # Section titles considered interesting to look variants into
 variant_titles: dict[str, tuple[str, ...]] = _populate("variant_titles")
+reverse_variant_titles: dict[str, tuple[str, ...]] = _populate("reverse_variant_titles")
 # Template names considered interesting to look variants into
 variant_templates: dict[str, tuple[str, ...]] = _populate("variant_templates")
+reverse_variant_templates: dict[str, tuple[str, ...]] = _populate("reverse_variant_templates")
 
 # Some definitions are not good to keep
 definitions_to_ignore: dict[str, tuple[str, ...]] = _populate("definitions_to_ignore")

--- a/wikidict/lang/defaults.py
+++ b/wikidict/lang/defaults.py
@@ -25,6 +25,10 @@ etyl_section = ("",)
 variant_titles: tuple[str, ...] = ()
 variant_templates: tuple[str, ...] = ()
 
+# Reverse variants
+reverse_variant_titles: tuple[str, ...] = ()
+reverse_variant_templates: tuple[str, ...] = ()
+
 # Some definitions are not good to keep
 definitions_to_ignore: tuple[str, ...] = ()
 

--- a/wikidict/lang/ro/__init__.py
+++ b/wikidict/lang/ro/__init__.py
@@ -61,6 +61,15 @@ variant_templates = (
     "{{flexion",
 )
 
+# Reverse variantes
+reverse_variant_titles = (
+    "{{adjectiv-",
+    "{{substantiv-",
+    "{{verb-",
+)
+reverse_variant_templates = ("{{rev-flexion",)
+
+
 # Templates more complex to manage.
 templates_multi = {
     # {{n}}
@@ -133,6 +142,8 @@ def last_template_handler(
 
 random_word_url = "https://ro.wiktionary.org/wiki/Special:RandomRootpage"
 
+REV_VARIANTS_IGNORED = {"-", "I", "II", "III", "IV", "V", "VI"}
+
 
 def adjust_wikicode(code: str, locale: str) -> str:
     # sourcery skip: inline-immediately-returned-variable
@@ -170,6 +181,13 @@ def adjust_wikicode(code: str, locale: str) -> str:
     '# {{flexion|frumos}}'
     >>> adjust_wikicode("#''formă alternativă pentru'' [[fântânioară]].", "ro")
     '# {{flexion|fântânioară}}'
+
+    >>> adjust_wikicode("{{substantiv-ron\\n|gen={{f}}\\n|nom-sg=piatră\\n|nom-pl=pietre\\n|art-sg=piatra\\n|art-pl=pietrele\\n|dat-sg=pietrei\\n|dat-pl=pietrelor\\n|voc-sg=piatră\\n|voc-pl=pietrelor\\n}}", "ro")
+    '# {{rev-flexion|piatra}}\\n# {{rev-flexion|piatră}}\\n# {{rev-flexion|pietre}}\\n# {{rev-flexion|pietrei}}\\n# {{rev-flexion|pietrele}}\\n# {{rev-flexion|pietrelor}}'
+    >>> adjust_wikicode("{{adjectiv-ron\\n|m-sg=interocular\\n|m-pl=[[interoculari]]\\n|f-sg=[[interoculară]]\\n|f-pl=interoculare/roof (2)\\n|voc-pl=\\n|voc-sg=electronică<br />electronico\\n}}", "ro")
+    '# {{rev-flexion|electronico}}\\n# {{rev-flexion|electronică}}\\n# {{rev-flexion|interocular}}\\n# {{rev-flexion|interoculare}}\\n# {{rev-flexion|interoculari}}\\n# {{rev-flexion|interoculară}}\\n# {{rev-flexion|roof}}'
+    >>> adjust_wikicode("{{adjectiv-ron|m-sg=interocular|m-pl=[[interoculari]]|f-sg=[[interoculară]]|f-pl=[[interoculare]]|voc-pl={{inv}}|voc-sg=}}# părul", "ro")
+    '# {{rev-flexion|interocular}}\\n# {{rev-flexion|interoculare}}\\n# {{rev-flexion|interoculari}}\\n# {{rev-flexion|interoculară}}\\n# părul'
     """
     locale_3_chars, lang_name = langs[locale]
 
@@ -222,5 +240,47 @@ def adjust_wikicode(code: str, locale: str) -> str:
         code,
         flags=re.MULTILINE,
     )
+
+    #
+    # Reverse variants
+    #
+
+    if any(tpl in code for tpl in reverse_variant_titles):
+        cleaned = []
+        in_tpl = False
+        tpl_code = ""
+
+        for line in code.splitlines():
+            line = line.strip()
+            if line.startswith(reverse_variant_titles):
+                in_tpl = True
+
+            if in_tpl:
+                tpl_code += line
+                if tpl_code.count("{") == tpl_code.count("}"):
+                    in_tpl = False
+                    tpl_code, rest = tpl_code.rsplit("}}", 1)
+                    forms: set[str] = set()
+                    for form in re.findall(r"=([^|{}]+)", tpl_code):
+                        if "(" in form:
+                            form = form.split("(", 1)[0]
+                        if "<br" in form:
+                            form = re.sub(r"<br\s?/?>", "/", form)
+                        if "/" in form:
+                            for sform in form.split("/"):
+                                forms.add(sform.strip("[]").strip())
+                        else:
+                            forms.add(form.strip("[]").strip())
+                    for discard in REV_VARIANTS_IGNORED:
+                        forms.discard(discard)
+                    cleaned.extend(f"# {{{{rev-flexion|{form}}}}}" for form in sorted(forms))
+                    if rest:
+                        cleaned.append(rest)
+                    tpl_code = ""
+                continue
+
+            cleaned.append(line)
+
+        code = "\n".join(cleaned)
 
     return code

--- a/wikidict/lang/ro/template_handlers.py
+++ b/wikidict/lang/ro/template_handlers.py
@@ -13,12 +13,24 @@ def render_variant(tpl: str, parts: list[str], data: defaultdict[str, str], *, w
     return parts[1] if "adj form of" in tpl else parts[-1]
 
 
+def render_reverse_variant(tpl: str, parts: list[str], data: defaultdict[str, str], *, word: str = "") -> str:
+    """
+    >>> render_reverse_variant("rev-flexion", ["pietrele"], defaultdict(str), word="piatră")
+    'pietrele'
+    """
+    return parts[0]
+
+
 template_mapping = {
     #
     # Variants
     #
     "__variant__adj form of": render_variant,
     "__variant__flexion": render_variant,
+    #
+    # Reverse variants
+    #
+    "__variant__rev-flexion": render_reverse_variant,
 }
 
 

--- a/wikidict/lang/ru/__init__.py
+++ b/wikidict/lang/ru/__init__.py
@@ -30,6 +30,7 @@ sections = (
 # Variants
 variant_titles = ("значение",)
 variant_templates = ("{{прич.",)
+reverse_variant_templates = ("{{rev-flexion",)
 
 # Some definitions are not good to keep
 templates_ignored = (

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -566,6 +566,7 @@ def parse_word(
     etymology = []
     etymology_sections: list[wtp.Section] = []
     variants: list[str] = []
+    reverse_variants: list[str] = []
 
     # Etymology (pre-select sections)
     if lang_src != "sv" and parsed_sections:
@@ -609,6 +610,7 @@ def parse_word(
     # Variants
     if parsed_sections and (interesting_titles := lang.variant_titles[lang_dst]):
         interesting_templates = lang.variant_templates[lang_dst]
+        interesting_templates_reverse = lang.reverse_variant_templates[lang_dst]
         for title, parsed_section in parsed_sections.items():
             if not title.startswith(interesting_titles):
                 continue
@@ -617,10 +619,14 @@ def parse_word(
                     tpl = str(tpl)
                     if tpl.startswith(interesting_templates):
                         add_potential_variant(word, tpl, lang_dst, variants)
+                    elif tpl.startswith(interesting_templates_reverse):
+                        add_potential_variant(word, tpl, lang_dst, reverse_variants)
         if variants:
             variants = sorted(set(variants))
+        if reverse_variants:
+            reverse_variants = sorted(set(reverse_variants))
 
-    return Word(prons, genders, etymology, definitions, variants)
+    return Word(prons, genders, etymology, definitions, variants, reverse_variants)
 
 
 def load(file: Path) -> dict[str, str]:
@@ -646,7 +652,7 @@ def render_word(
     except Exception:
         log.exception("ERROR with %r", word)
     else:
-        if details.definitions or details.variants:
+        if details.definitions or details.variants or details.reverse_variants:
             words[word] = details
             return details
 
@@ -668,6 +674,15 @@ def render(in_words: dict[str, str], locale: str, workers: int) -> Words:
         )
 
     utils.check_for_missing_templates(list(all_templates))
+
+    log.info("Handling reverse variants ...")
+    for word, details in results.items():
+        for form in details.reverse_variants:
+            try:
+                results[form].variants = sorted({*results[form].variants, word})
+            except KeyError:
+                results[form] = Word([], [], [], {}, [word], [])
+    log.info("Handling reverse variants ... Done")
 
     return results.copy()
 

--- a/wikidict/stubs.py
+++ b/wikidict/stubs.py
@@ -16,6 +16,7 @@ class Word:
     etymology: list[Definition]
     definitions: Definitions
     variants: list[str]
+    reverse_variants: list[str]
     is_variant: bool = False
 
 


### PR DESCRIPTION
As an example, for the RO dictionary, the variants count goes:
- from  25,634
-   to 297,467

Closes #2085.

I will extend the feature to other locales soon.
