### PR TITLE
fix #2534: Use the 'redirect' key for more reverse variants

### DIFF
--- a/wikidict/constants.py
+++ b/wikidict/constants.py
@@ -68,3 +68,7 @@ HTML_REPL_BODY = {
     "&quot;": '"',
 }
 HTML_REPL_TITLE = {"&amp;": "&"}
+
+# Redirect key. This constant is used to mark a word as a redirect in --parse,
+# and to detect it and handle it --render
+REDIRECT_KEY = "##REDIRECT##"

--- a/wikidict/parse.py
+++ b/wikidict/parse.py
@@ -97,9 +97,13 @@ def xml_parse_element(
 
     # Word
     elif title := next(RE_TITLE_WORD(element), None):
-        text = next(RE_TEXT(element, pos=element.find("<text", title.endpos)), "")
-        if text and next(head_sections_matcher(wikicode := text[1]), None):
-            return title[1], wikicode
+        if redirect := next(RE_REDIRECT(element, endpos=element.find("<revision")), None):
+            redirect_to = redirect[1]
+            return title[1], f"{constants.REDIRECT_KEY}{redirect_to}"
+        else:
+            text = next(RE_TEXT(element, pos=element.find("<text", title.endpos)), "")
+            if text and next(head_sections_matcher(wikicode := text[1]), None):
+                return title[1], wikicode
 
         if DEBUG_PARSE:
             try:

--- a/wikidict/render.py
+++ b/wikidict/render.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 import wikitextparser as wtp
 import wikitextparser._spans
 
-from . import context, lang, utils
+from . import constants, context, lang, utils
 from .stubs import Definition, Definitions, Word
 
 if TYPE_CHECKING:
@@ -480,6 +480,10 @@ def parse_word(
     It is disabled by default to speed-up the overall process, but enabled when
     called from `get_word.get_and_parse_word()`.
     """
+    redirect = ""
+    if code.startswith(constants.REDIRECT_KEY):
+        redirect = code.split(constants.REDIRECT_KEY)[-1].strip()
+        return Word([], [], [], {}, [], [redirect])
     # Init the Lua interpreter for this word
     if DEBUG_LUA:
         log.info(word)
@@ -623,15 +627,16 @@ def render(in_words: dict[str, str], locale: str, workers: int) -> Words:
     utils.check_for_templates_status(templates_status._getvalue())
 
     log.info("Handling reverse variants ...")
-    for word, details in results.items():
+    results_return: dict[str, Word] = dict(results)  # important, convert to a real dict so we can modify it
+    for word, details in list(results_return.items()):
         for form in details.reverse_variants:
             try:
-                results[form].variants = sorted({*results[form].variants, word})
+                results_return[form].variants = sorted({*results_return[form].variants, word})
             except KeyError:
-                results[form] = Word([], [], [], {}, [word], [])
+                results_return[form] = Word([], [], [], {}, [word], [])
     log.info("Handling reverse variants ... Done")
 
-    return results._getvalue()  # type: ignore[no-any-return]
+    return results_return
 
 
 def save(output: Path, words: Words) -> None:


### PR DESCRIPTION
Fixes #2534
Also fix the handling of reverse_variants at the end of render.