### PR TITLE
feat(webapp): gzip volumes

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
 
                 const volumeName = String(volumeNum).padStart(8, '0');
                 try {
-                    const filename = `vol-${volumeName}.json`;
+                    const filename = `vol-${volumeName}.json.gz`;
                     const response = await fetch(`${this.basePath}${filename}`);
                     const volume = await response.json();
 

--- a/server.py
+++ b/server.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import mimetypes
+import os
+
+PORT = 8000
+
+class GzipStaticHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        # If the requested file ends with .gz, add Content-Encoding
+        if self.path.endswith(".gz"):
+            self.send_header("Content-Encoding", "gzip")
+
+            # Try to infer the original MIME type (e.g., .js.gz -> .js)
+            base, _ = os.path.splitext(self.path)
+            mime, _ = mimetypes.guess_type(base)
+            if mime:
+                self.send_header("Content-Type", mime)
+
+        super().end_headers()
+
+
+if __name__ == "__main__":
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("", PORT), GzipStaticHandler) as httpd:
+        print(f"Serving HTTP on port {PORT} (http://localhost:{PORT}/)")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nShutting down server.")
+            httpd.server_close()

--- a/wikidict/convert.py
+++ b/wikidict/convert.py
@@ -647,7 +647,7 @@ class JSONVolumeFormat(BaseFormat):
     """Save the data into JSON volumes with range-based splitting."""
 
     output_file = "jsonvolume-{lang_src}-{lang_dst}{etym_suffix}"
-    max_volume_size_kb = 200  # Target volume size in KB
+    max_volume_size_kb = 1024  # Target volume size in KB
     max_volume_bytes = max_volume_size_kb * 1024
 
     KEY_DEFINITION = "d"
@@ -810,11 +810,15 @@ class JSONVolumeFormat(BaseFormat):
         """Save a single volume and return its metadata."""
         volume_data = {"words": words}
 
-        filename = f"vol-{volume_num:08d}.json"
+        filename = f"vol-{volume_num:08d}.json.gz"
         filepath = output_dir / filename
 
-        filepath.write_text(json.dumps(volume_data, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
-        file_size = self._estimate_json_size(volume_data)
+        # Write gzipped JSON
+        json_content = json.dumps(volume_data, ensure_ascii=False, separators=(",", ":"))
+        with gzip.open(filepath, "wt", encoding="utf-8") as f:
+            f.write(json_content)
+
+        file_size = filepath.stat().st_size  # Get actual compressed file size
 
         log.info(
             "[%s] Volume %s: %s → %s (%s words, %sKB)",


### PR DESCRIPTION
* Volumes size is now 1Mb; so around 256k max for fr once gzipped.
* I provided a server.py to test and serve the files with the right Content-Encoding. No simple one liner AFAIK.
